### PR TITLE
Adding cache for Lychee link checker action

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -107,16 +107,32 @@ jobs:
         working-directory: docs
       - run: npx -y http-server@14.1.1 ./docs/.vitepress/dist -p 4174 >/tmp/slide-spec-docs.log 2>&1 &
       - run: sleep 2
+      - id: lychee-cache-bucket
+        run: echo "bucket=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+      # actions/cache/restore@v5.0.4
+      - id: restore-lychee-cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        with:
+          path: .lycheecache
+          key: lychee-${{ runner.os }}-v1-${{ steps.lychee-cache-bucket.outputs.bucket }}
+          restore-keys: |
+            lychee-${{ runner.os }}-v1-
       # lycheeverse/lychee-action@v2.8.0
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
-          args: --verbose --no-progress --config .github/lychee.toml "./README.md"
+          args: --cache --max-cache-age 14d --verbose --no-progress --config .github/lychee.toml "./README.md"
           fail: true
       # lycheeverse/lychee-action@v2.8.0
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
-          args: --verbose --no-progress --config .github/lychee.toml --base-url "http://127.0.0.1:4174/" "./docs/.vitepress/dist/**/*.html"
+          args: --cache --max-cache-age 14d --verbose --no-progress --config .github/lychee.toml --base-url "http://127.0.0.1:4174/" "./docs/.vitepress/dist/**/*.html"
           fail: true
+      # actions/cache/save@v5.0.4
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        if: always()
+        with:
+          path: .lycheecache
+          key: ${{ steps.restore-lychee-cache.outputs.cache-primary-key }}
 
   trivy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #20 

Adds a cache for lychee link-checker to avoid rate limits and temporary network failures. Cache invalidates after 14 days.  Caches are not shared across branches, but this should at least help for individual PRs and the main branch actions.