### PR TITLE
Video now CDN hosted by GH in user-attachments bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <!-- TODO: replace placeholder URLs for demo and docs once deployed -->
 [Live Demo](https://TODO-demo-url) · [Docs](https://TODO-docs-url) · [Example YAML](content/)
 
-<video src="https://github.com/lreading/slide-spec/raw/main/assets/readme-demo.mp4" controls muted width="600"></video>
+https://github.com/user-attachments/assets/076d3140-4d1d-47a3-8f5b-5a1dd58f03c1
 
 </div>
 


### PR DESCRIPTION
## What

Hack to host the video in the readme - uploading the video to a GH issue (even without posting it) adds it to the GH CDN.  Linking the CDN url should make the video embed in the readme.

## Related issue

<!-- Link the issue this PR addresses. An issue is required before opening a PR. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Breaking changes

<!-- Does this PR introduce a breaking change? Slide Spec follows semver - breaking changes must be clearly documented. -->

- [ ] Yes (describe below)
- [x] No

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [ ] I have tested this locally
- [ ] Quality gates pass (see project READMEs for specific gates)
- [ ] Documentation is updated (if applicable)
- [ ] No unnecessary dependency changes
