### PR TITLE
Lychee link checker updates

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,2 +1,7 @@
 verbose = "info"
-exclude = ["todo-demo-url", "todo-docs-url", "npmjs\\.com"]
+exclude = [
+  "todo-demo-url",
+  "todo-docs-url",
+  "npmjs\\.com",
+  "^https://github\\.com/user-attachments/assets/076d3140-4d1d-47a3-8f5b-5a1dd58f03c1$",
+]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![npm](https://img.shields.io/npm/v/@slide-spec/cli)](https://www.npmjs.com/package/@slide-spec/cli)
 [![CI](https://img.shields.io/github/actions/workflow/status/lreading/slide-spec/main.yml?branch=main&label=CI)](https://github.com/lreading/slide-spec/actions/workflows/main.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12235/badge)](https://www.bestpractices.dev/projects/12235)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12235/badge)](https://www.bestpractices.dev/en/projects/12235/passing)
 
 <!-- TODO: replace placeholder URLs for demo and docs once deployed -->
 [Live Demo](https://TODO-demo-url) · [Docs](https://TODO-docs-url) · [Example YAML](content/)


### PR DESCRIPTION
## What

Ignores the GH CDN url for the README video
Updates the bestpractices.dev url so it doesn't need to redirect multiple times

## Related issue

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Breaking changes

- [ ] Yes (describe below)
- [x] No

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [ ] Quality gates pass (see project READMEs for specific gates)
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes
