### PR TITLE
Fix static routing for generated sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Before handoff, run every local command needed to give high confidence that the 
 - Respect existing Vue 3 and Playwright patterns.
 - Any user-visible UI change should trigger review of unit, e2e, a11y, and visual coverage.
 - Treat accessibility, deterministic output, and static-site generation as release-quality requirements.
+- When adding or changing app routes, update static route entrypoint generation, `sitemap.xml`/`llms.txt` behavior, and route/deep-link tests in the same change.
 
 ### `cli/`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ As a practical rule:
 - If you changed product code, run the relevant package verify command and any missing checks needed for confidence.
 - If you changed docs, make sure docs build cleanly and the markdown, spellcheck, and link checks still make sense.
 - If you changed UI or rendering, think about unit tests, e2e coverage, accessibility, and visual regression impact together.
+- If you changed app routes, make sure direct links and hard refreshes work in static builds and update sitemap/LLM metadata behavior if the public route surface changed.
 
 ## Common GitHub Actions failures
 

--- a/cli/src/runtime/SiteArtifactGenerator.spec.ts
+++ b/cli/src/runtime/SiteArtifactGenerator.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 
@@ -31,6 +31,7 @@ describe('SiteArtifactGenerator', () => {
     const projectRoot = await workspace.create()
     const outputRoot = resolve(projectRoot, 'dist')
     await mkdir(outputRoot, { recursive: true })
+    await writeFile(resolve(outputRoot, 'index.html'), '<!doctype html><title>Slide Spec</title>', 'utf8')
 
     await new SiteArtifactGenerator().generate({
       outputRoot,
@@ -48,22 +49,50 @@ describe('SiteArtifactGenerator', () => {
       '<loc>https://updates.example.test/presentations/public-one</loc>',
     )
     await expect(readFile(resolve(outputRoot, 'sitemap.xml'), 'utf8')).resolves.not.toContain('draft-two')
+    await expect(readFile(resolve(outputRoot, 'presentations', 'index.html'), 'utf8')).resolves.toBe(
+      '<!doctype html><title>Slide Spec</title>',
+    )
+    await expect(readFile(resolve(outputRoot, 'presentations', 'public-one', 'index.html'), 'utf8')).resolves.toBe(
+      '<!doctype html><title>Slide Spec</title>',
+    )
+    await expect(readFile(resolve(outputRoot, 'presentations', 'draft-two', 'index.html'), 'utf8')).rejects.toThrow()
   })
 
   it('omits the sitemap when no deployment url is configured', async () => {
     const projectRoot = await workspace.create()
     const outputRoot = resolve(projectRoot, 'dist')
     await mkdir(outputRoot, { recursive: true })
+    await writeFile(resolve(outputRoot, 'index.html'), '<!doctype html><title>Slide Spec</title>', 'utf8')
 
     await new SiteArtifactGenerator().generate({
       outputRoot,
       siteUrl: undefined,
       sitemapEnabled: false,
-      publishedPresentationIds: [],
+      publishedPresentationIds: ['offline-deck'],
     })
 
     await expect(readFile(resolve(outputRoot, 'robots.txt'), 'utf8')).resolves.toBe('User-agent: *\nAllow: /\n')
     await expect(readFile(resolve(outputRoot, 'llms.txt'), 'utf8')).rejects.toThrow()
     await expect(readFile(resolve(outputRoot, 'sitemap.xml'), 'utf8')).rejects.toThrow()
+    await expect(readFile(resolve(outputRoot, 'presentations', 'index.html'), 'utf8')).resolves.toBe(
+      '<!doctype html><title>Slide Spec</title>',
+    )
+    await expect(readFile(resolve(outputRoot, 'presentations', 'offline-deck', 'index.html'), 'utf8')).resolves.toBe(
+      '<!doctype html><title>Slide Spec</title>',
+    )
+  })
+
+  it('rejects presentation ids that cannot be written as static route segments', async () => {
+    const projectRoot = await workspace.create()
+    const outputRoot = resolve(projectRoot, 'dist')
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(resolve(outputRoot, 'index.html'), '<!doctype html><title>Slide Spec</title>', 'utf8')
+
+    await expect(new SiteArtifactGenerator().generate({
+      outputRoot,
+      siteUrl: 'https://updates.example.test',
+      sitemapEnabled: true,
+      publishedPresentationIds: ['../escape'],
+    })).rejects.toThrow('Presentation id "../escape" cannot be used as a static route segment.')
   })
 })

--- a/docs/meta/cloudflare-pages.md
+++ b/docs/meta/cloudflare-pages.md
@@ -83,6 +83,8 @@ npx @slide-spec/cli build --deployment-url https://updates.example.com
 
 In most cases it is cleaner to set `site.deployment_url` in `content/site.yaml` and keep the build command simple.
 
+The build output includes static entry points for the presentations index and each published presentation, for example `dist/presentations/index.html` and `dist/presentations/2026-launch/index.html`. Those files let deep links and hard refreshes work on static hosts without switching the app to hash-based routing.
+
 ---
 
 ## Step 3: Make sure the repo already contains generated content
@@ -178,5 +180,6 @@ That gives you a simple deployment model without giving up CI.
 | Build fails because `@slide-spec/cli` is not found | Confirm the package is published and the Pages environment can install from npm. |
 | Site deploys but content is wrong | Run `npx @slide-spec/cli validate` locally and verify the committed YAML, especially `generated.yaml`. |
 | Sitemap is missing | Set `site.deployment_url` in `content/site.yaml`, or pass `--deployment-url` in the build command. |
+| Direct links under `/presentations` return 404 | Confirm the uploaded `dist` directory includes `presentations/index.html` and `presentations/<id>/index.html` for each published deck. |
 | Project is in a subdirectory and Pages cannot find it | Set the Pages root directory to that subdirectory, such as `slides`. |
 | You need fresh GitHub data on every deploy | That is the case where a GitHub Action or another external fetch pipeline may be worth adding. |

--- a/shared/src/site-artifact-generator.ts
+++ b/shared/src/site-artifact-generator.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
 export interface SiteArtifactGeneratorOptions {
@@ -22,6 +22,7 @@ export class SiteArtifactGenerator {
       const sitemapXml = this.buildSitemap(siteUrl, options.publishedPresentationIds)
       await this.writeOutput(resolve(options.outputRoot, 'sitemap.xml'), sitemapXml)
     }
+    await this.writeRouteEntrypoints(options.outputRoot, options.publishedPresentationIds)
   }
 
   private buildSitemap(siteUrl: URL, publishedPresentationIds: string[]): string {
@@ -75,5 +76,23 @@ export class SiteArtifactGenerator {
   private async writeOutput(path: string, contents: string): Promise<void> {
     await mkdir(dirname(path), { recursive: true })
     await writeFile(path, contents, 'utf8')
+  }
+
+  private async writeRouteEntrypoints(outputRoot: string, publishedPresentationIds: string[]): Promise<void> {
+    const indexHtml = await readFile(resolve(outputRoot, 'index.html'), 'utf8')
+
+    await this.writeOutput(resolve(outputRoot, 'presentations', 'index.html'), indexHtml)
+    await Promise.all(
+      publishedPresentationIds.map(async (presentationId) => {
+        this.assertSafeRouteSegment(presentationId)
+        await this.writeOutput(resolve(outputRoot, 'presentations', presentationId, 'index.html'), indexHtml)
+      }),
+    )
+  }
+
+  private assertSafeRouteSegment(segment: string): void {
+    if (segment === '.' || segment === '..' || segment.includes('/') || segment.includes('\\')) {
+      throw new Error(`Presentation id "${segment}" cannot be used as a static route segment.`)
+    }
   }
 }


### PR DESCRIPTION
## What

Fixes static routing.  Currently, you cannot deep-link to presentation pages.

## Related issue

Relates to #84 
Not closing yet as I need to validate after deployment/

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Breaking changes

- [ ] Yes (describe below)
- [x] No

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [x] Quality gates pass (see project READMEs for specific gates)
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes
