### PR TITLE
Add public JSON Schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ The core audience is comfortable with source control, static sites, and YAML dat
 
 - If behavior changes, update documentation in the same task.
 - If schema, config, CLI flags, generated data, templates, or connector behavior change, update the relevant docs and examples before calling the work complete.
+- If the YAML schema changes, update the public JSON Schema files, schema tests, docs, examples, and scaffolded templates in the same task.
 - Do not leave placeholder copy, TODO-style public docs, or undocumented options.
 - Keep README, package READMEs, docs pages, examples, and CLI help aligned.
 - Keep `AGENTS.md`, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md` aligned when shared expectations change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ If you only read one section, read this one:
 - Explicit configuration instead of magic behavior
 - Secure defaults
 - Updated docs, examples, or help text when user-facing behavior changes
+- Updated public JSON Schemas and schema tests when YAML fields or validation behavior change
 - Tests that cover the behavior you changed
 
 Slide Spec is primarily for people comfortable with source control and YAML data files. That means clarity matters more than cleverness.

--- a/app/e2e/fixtures/content-cli-demo/presentations/2026-demo/generated.yaml
+++ b/app/e2e/fixtures/content-cli-demo/presentations/2026-demo/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-demo

--- a/app/e2e/fixtures/content-cli-demo/presentations/2026-demo/presentation.yaml
+++ b/app/e2e/fixtures/content-cli-demo/presentations/2026-demo/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-demo
@@ -28,27 +29,21 @@ presentation:
       title: Roadmap
       content:
         stage: completed
-        sections:
+        stages:
           completed:
             label: Completed
             summary: Default roadmap fixture content.
-            items: []
-            themes: []
           in-progress:
             label: In Progress
             summary: Default roadmap fixture content.
-            items: []
-            themes: []
           planned:
             label: Planned
             summary: Default roadmap fixture content.
-            items: []
-            themes: []
           future:
             label: Future
             summary: Default roadmap fixture content.
-            items: []
-            themes: []
+        items: []
+        themes: []
     - template: people
       enabled: true
       title: Contributors

--- a/app/e2e/fixtures/content-cli-demo/presentations/index.yaml
+++ b/app/e2e/fixtures/content-cli-demo/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-demo

--- a/app/e2e/fixtures/content-cli-demo/site.yaml
+++ b/app/e2e/fixtures/content-cli-demo/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Slide Spec

--- a/app/e2e/fixtures/content-demo/presentations/index.yaml
+++ b/app/e2e/fixtures/content-demo/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: readme-demo

--- a/app/e2e/fixtures/content-demo/presentations/readme-demo/generated.yaml
+++ b/app/e2e/fixtures/content-demo/presentations/readme-demo/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: readme-demo

--- a/app/e2e/fixtures/content-demo/presentations/readme-demo/presentation.yaml
+++ b/app/e2e/fixtures/content-demo/presentations/readme-demo/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: readme-demo

--- a/app/e2e/fixtures/content-demo/site.yaml
+++ b/app/e2e/fixtures/content-demo/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Acorn Cloud Updates

--- a/app/e2e/fixtures/content/presentations/2025-04-community-office-hours/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-04-community-office-hours/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-04-community-office-hours

--- a/app/e2e/fixtures/content/presentations/2025-04-community-office-hours/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-04-community-office-hours/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-04-community-office-hours

--- a/app/e2e/fixtures/content/presentations/2025-05-release-recap/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-05-release-recap/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-05-release-recap

--- a/app/e2e/fixtures/content/presentations/2025-05-release-recap/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-05-release-recap/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-05-release-recap

--- a/app/e2e/fixtures/content/presentations/2025-06-roadmap-deep-dive/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-06-roadmap-deep-dive/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-06-roadmap-deep-dive

--- a/app/e2e/fixtures/content/presentations/2025-06-roadmap-deep-dive/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-06-roadmap-deep-dive/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-06-roadmap-deep-dive

--- a/app/e2e/fixtures/content/presentations/2025-07-maintainer-sync/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-07-maintainer-sync/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-07-maintainer-sync

--- a/app/e2e/fixtures/content/presentations/2025-07-maintainer-sync/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-07-maintainer-sync/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-07-maintainer-sync

--- a/app/e2e/fixtures/content/presentations/2025-08-design-review/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-08-design-review/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-08-design-review

--- a/app/e2e/fixtures/content/presentations/2025-08-design-review/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-08-design-review/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-08-design-review

--- a/app/e2e/fixtures/content/presentations/2025-09-platform-update/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-09-platform-update/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-09-platform-update

--- a/app/e2e/fixtures/content/presentations/2025-09-platform-update/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-09-platform-update/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-09-platform-update

--- a/app/e2e/fixtures/content/presentations/2025-10-interoperability-notes/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-10-interoperability-notes/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-10-interoperability-notes

--- a/app/e2e/fixtures/content/presentations/2025-10-interoperability-notes/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-10-interoperability-notes/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-10-interoperability-notes

--- a/app/e2e/fixtures/content/presentations/2025-11-community-roundup/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-11-community-roundup/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-11-community-roundup

--- a/app/e2e/fixtures/content/presentations/2025-11-community-roundup/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-11-community-roundup/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-11-community-roundup

--- a/app/e2e/fixtures/content/presentations/2025-12-release-review/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-12-release-review/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-12-release-review

--- a/app/e2e/fixtures/content/presentations/2025-12-release-review/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-12-release-review/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-12-release-review

--- a/app/e2e/fixtures/content/presentations/2025-template-sparse/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-template-sparse/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-template-sparse

--- a/app/e2e/fixtures/content/presentations/2025-template-sparse/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-template-sparse/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-template-sparse

--- a/app/e2e/fixtures/content/presentations/2026-01-weekly-briefing/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2026-01-weekly-briefing/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-01-weekly-briefing

--- a/app/e2e/fixtures/content/presentations/2026-01-weekly-briefing/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2026-01-weekly-briefing/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-01-weekly-briefing

--- a/app/e2e/fixtures/content/presentations/2026-02-weekly-briefing/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2026-02-weekly-briefing/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-02-weekly-briefing

--- a/app/e2e/fixtures/content/presentations/2026-02-weekly-briefing/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2026-02-weekly-briefing/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-02-weekly-briefing

--- a/app/e2e/fixtures/content/presentations/2026-03-weekly-briefing/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2026-03-weekly-briefing/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-03-weekly-briefing

--- a/app/e2e/fixtures/content/presentations/2026-03-weekly-briefing/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2026-03-weekly-briefing/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-03-weekly-briefing

--- a/app/e2e/fixtures/content/presentations/2026-q1/generated.yaml
+++ b/app/e2e/fixtures/content/presentations/2026-q1/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1

--- a/app/e2e/fixtures/content/presentations/2026-q1/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2026-q1/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1

--- a/app/e2e/fixtures/content/presentations/index.yaml
+++ b/app/e2e/fixtures/content/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
 - id: 2026-q1

--- a/app/e2e/fixtures/content/site.yaml
+++ b/app/e2e/fixtures/content/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Threat Dragon Quarterly Updates

--- a/cli/examples-synced/community-update/presentations/2026-q1-community/generated.yaml
+++ b/cli/examples-synced/community-update/presentations/2026-q1-community/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1-community

--- a/cli/examples-synced/community-update/presentations/2026-q1-community/presentation.yaml
+++ b/cli/examples-synced/community-update/presentations/2026-q1-community/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1-community

--- a/cli/examples-synced/community-update/presentations/index.yaml
+++ b/cli/examples-synced/community-update/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-q1-community

--- a/cli/examples-synced/community-update/site.yaml
+++ b/cli/examples-synced/community-update/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Prism Community Updates

--- a/cli/examples-synced/open-source-update/presentations/2026-q1-update/generated.yaml
+++ b/cli/examples-synced/open-source-update/presentations/2026-q1-update/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1-update

--- a/cli/examples-synced/open-source-update/presentations/2026-q1-update/presentation.yaml
+++ b/cli/examples-synced/open-source-update/presentations/2026-q1-update/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1-update

--- a/cli/examples-synced/open-source-update/presentations/index.yaml
+++ b/cli/examples-synced/open-source-update/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-q1-update

--- a/cli/examples-synced/open-source-update/site.yaml
+++ b/cli/examples-synced/open-source-update/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Vortex CLI Updates

--- a/cli/examples-synced/product-review/presentations/2026-q1-review/generated.yaml
+++ b/cli/examples-synced/product-review/presentations/2026-q1-review/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1-review

--- a/cli/examples-synced/product-review/presentations/2026-q1-review/presentation.yaml
+++ b/cli/examples-synced/product-review/presentations/2026-q1-review/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1-review

--- a/cli/examples-synced/product-review/presentations/index.yaml
+++ b/cli/examples-synced/product-review/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-q1-review

--- a/cli/examples-synced/product-review/site.yaml
+++ b/cli/examples-synced/product-review/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Meridian Product Reviews

--- a/cli/examples-synced/security-posture/presentations/2026-q1-posture/generated.yaml
+++ b/cli/examples-synced/security-posture/presentations/2026-q1-posture/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1-posture

--- a/cli/examples-synced/security-posture/presentations/2026-q1-posture/presentation.yaml
+++ b/cli/examples-synced/security-posture/presentations/2026-q1-posture/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1-posture

--- a/cli/examples-synced/security-posture/presentations/index.yaml
+++ b/cli/examples-synced/security-posture/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-q1-posture

--- a/cli/examples-synced/security-posture/site.yaml
+++ b/cli/examples-synced/security-posture/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Sentinel Security Reports

--- a/cli/src/application/TdCliApplicationService.spec.ts
+++ b/cli/src/application/TdCliApplicationService.spec.ts
@@ -441,11 +441,17 @@ describe('TdCliApplicationService', () => {
     })
 
     expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain('schemaVersion:')
+    expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain(
+      '# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json',
+    )
     expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain('https://github.com/example/project')
     expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain('https://example.com/docs')
     expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain('https://example.com')
     expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain('data_sources:')
     expect(fileSystem.writes.get('/repo/content/presentations/2026-q1/presentation.yaml')).toContain('schemaVersion:')
+    expect(fileSystem.writes.get('/repo/content/presentations/2026-q1/presentation.yaml')).toContain(
+      '# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json',
+    )
     expect(fileSystem.writes.get('/repo/content/presentations/2026-q1/presentation.yaml')).toContain('template: hero')
     expect(generatedDataStore.writes).toHaveLength(1)
     expect(presentationIndexStore.writes).toHaveLength(1)

--- a/cli/src/application/TdCliApplicationService.ts
+++ b/cli/src/application/TdCliApplicationService.ts
@@ -1,4 +1,5 @@
 import { ExampleRegistry } from '../examples/ExampleRegistry'
+import { slideSpecSchemaUrls } from '../../../shared/src/json-schema-urls'
 import { ContentConfigLoader } from '../config/ContentConfigLoader'
 import { DataSourceResolver } from '../config/DataSourceResolver'
 import { EnvLoader } from '../config/EnvLoader'
@@ -141,7 +142,7 @@ export class TdCliApplicationService implements TdCliService {
         ...(input.docsUrl !== undefined ? { docsUrl: input.docsUrl } : {}),
         ...(input.websiteUrl !== undefined ? { websiteUrl: input.websiteUrl } : {}),
         ...(input.githubDataSourceUrl !== undefined ? { githubDataSourceUrl: input.githubDataSourceUrl } : {}),
-      }))
+      }), { schemaUrl: slideSpecSchemaUrls.site })
       createdPaths.push(paths.getSiteConfigPath())
     }
     const presentationPath = paths.getPresentationPath(input.presentationId)
@@ -149,7 +150,9 @@ export class TdCliApplicationService implements TdCliService {
       id: input.presentationId,
     })
 
-    await this.yamlWriter.writeDocument(presentationPath, presentationDocument)
+    await this.yamlWriter.writeDocument(presentationPath, presentationDocument, {
+      schemaUrl: slideSpecSchemaUrls.presentation,
+    })
     await this.generatedDataStore.writeGeneratedData(paths, { id: input.presentationId }, generatedDocument)
     createdPaths.push(presentationPath, generatedPath)
 

--- a/cli/src/generation/GeneratedDataStore.spec.ts
+++ b/cli/src/generation/GeneratedDataStore.spec.ts
@@ -91,6 +91,9 @@ generated:
     })).resolves.toBe('/workspace/project/content/presentations/2026-q1/generated.yaml')
 
     expect(fileSystem.files.get('/workspace/project/content/presentations/2026-q1/generated.yaml')).toContain(
+      '# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json',
+    )
+    expect(fileSystem.files.get('/workspace/project/content/presentations/2026-q1/generated.yaml')).toContain(
       'schemaVersion:',
     )
     expect(fileSystem.files.get('/workspace/project/content/presentations/2026-q1/generated.yaml')).toContain(

--- a/cli/src/generation/GeneratedDataStore.ts
+++ b/cli/src/generation/GeneratedDataStore.ts
@@ -1,4 +1,5 @@
 import { SLIDE_SPEC_SCHEMA_VERSION } from '../../../shared/src/content'
+import { slideSpecSchemaUrls } from '../../../shared/src/json-schema-urls'
 import { YamlReader } from '../io/YamlReader'
 import { YamlWriter } from '../io/YamlWriter'
 
@@ -52,6 +53,8 @@ export class GeneratedDataStore {
     await this.yamlWriter.writeDocument(generatedPath, {
       schemaVersion: SLIDE_SPEC_SCHEMA_VERSION,
       generated,
+    }, {
+      schemaUrl: slideSpecSchemaUrls.generated,
     })
     return generatedPath
   }

--- a/cli/src/init/PresentationIndexStore.spec.ts
+++ b/cli/src/init/PresentationIndexStore.spec.ts
@@ -82,6 +82,7 @@ presentations:
     ])
 
     const content = fileSystem.files.get('/workspace/project/content/presentations/index.yaml') ?? ''
+    expect(content).toContain('# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json')
     expect(content).toContain('schemaVersion:')
     expect(content.indexOf('id: 2025-q4')).toBeLessThan(content.indexOf('id: 2026-q1'))
   })
@@ -170,6 +171,7 @@ presentations:
     ])
 
     const content = fileSystem.files.get('/workspace/project/content/presentations/index.yaml') ?? ''
+    expect(content).toContain('# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json')
     expect(content).toContain('schemaVersion:')
     expect(content).toContain('presentation_path: presentations/2026-q1/presentation.yaml')
     expect(content).toContain('generated_path: presentations/2026-q1/generated.yaml')

--- a/cli/src/init/PresentationIndexStore.ts
+++ b/cli/src/init/PresentationIndexStore.ts
@@ -1,4 +1,5 @@
 import { SLIDE_SPEC_SCHEMA_VERSION } from '../../../shared/src/content'
+import { slideSpecSchemaUrls } from '../../../shared/src/json-schema-urls'
 import { PresentationIndexLoader } from '../generation/PresentationIndexLoader'
 import { YamlWriter } from '../io/YamlWriter'
 
@@ -34,6 +35,8 @@ export class PresentationIndexStore {
     await this.yamlWriter.writeDocument(paths.getPresentationsIndexPath(), {
       schemaVersion: SLIDE_SPEC_SCHEMA_VERSION,
       presentations: entries,
+    }, {
+      schemaUrl: slideSpecSchemaUrls.presentationsIndex,
     })
   }
 }

--- a/cli/src/io/YamlWriter.spec.ts
+++ b/cli/src/io/YamlWriter.spec.ts
@@ -44,4 +44,17 @@ describe('YamlWriter', () => {
     expect(fileSystem.writes.get('/tmp/generated.yaml')).toContain('generated:')
     expect(fileSystem.writes.get('/tmp/generated.yaml')).toContain('id: 2026-q1')
   })
+
+  it('prepends a yaml language server schema comment when a schema URL is provided', async () => {
+    const fileSystem = new MemoryFileSystem()
+    const writer = new YamlWriter(fileSystem)
+
+    await writer.writeDocument('/tmp/site.yaml', { schemaVersion: 1, site: {} }, {
+      schemaUrl: 'https://slide-spec.dev/schema/site.schema.json',
+    })
+
+    expect(fileSystem.writes.get('/tmp/site.yaml')?.startsWith(
+      '# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json\n',
+    )).toBe(true)
+  })
 })

--- a/cli/src/io/YamlWriter.ts
+++ b/cli/src/io/YamlWriter.ts
@@ -4,10 +4,18 @@ import { NodeFileSystem } from './FileSystem'
 
 import type { FileSystem } from './FileSystem'
 
+interface WriteYamlDocumentOptions {
+  schemaUrl?: string
+}
+
 export class YamlWriter {
   public constructor(private readonly fileSystem: FileSystem = new NodeFileSystem()) {}
 
-  public async writeDocument(path: string, document: unknown): Promise<void> {
-    await this.fileSystem.writeTextFile(path, stringify(document))
+  public async writeDocument(path: string, document: unknown, options: WriteYamlDocumentOptions = {}): Promise<void> {
+    const schemaComment = options.schemaUrl
+      ? `# yaml-language-server: $schema=${options.schemaUrl}\n`
+      : ''
+
+    await this.fileSystem.writeTextFile(path, `${schemaComment}${stringify(document)}`)
   }
 }

--- a/content/presentations/2025-template-sparse/generated.yaml
+++ b/content/presentations/2025-template-sparse/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-template-sparse

--- a/content/presentations/2025-template-sparse/presentation.yaml
+++ b/content/presentations/2025-template-sparse/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-template-sparse

--- a/content/presentations/2026-q1/generated.yaml
+++ b/content/presentations/2026-q1/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1

--- a/content/presentations/2026-q1/presentation.yaml
+++ b/content/presentations/2026-q1/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1

--- a/content/presentations/index.yaml
+++ b/content/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-q1

--- a/content/site.yaml
+++ b/content/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Threat Dragon Quarterly Updates

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -49,3 +49,5 @@ content/
 ```
 
 If `site.yaml` or `index.yaml` already exist, they are updated rather than overwritten (unless `--force` is used).
+
+Scaffolded YAML files include `yaml-language-server` comments that point to the public Slide Spec JSON Schemas for editor validation and autocomplete.

--- a/docs/fixtures/reference-project/content/presentations/2025-winter-summary/generated.yaml
+++ b/docs/fixtures/reference-project/content/presentations/2025-winter-summary/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-winter-summary

--- a/docs/fixtures/reference-project/content/presentations/2025-winter-summary/presentation.yaml
+++ b/docs/fixtures/reference-project/content/presentations/2025-winter-summary/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-winter-summary

--- a/docs/fixtures/reference-project/content/presentations/2026-spring-briefing/generated.yaml
+++ b/docs/fixtures/reference-project/content/presentations/2026-spring-briefing/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-spring-briefing

--- a/docs/fixtures/reference-project/content/presentations/2026-spring-briefing/presentation.yaml
+++ b/docs/fixtures/reference-project/content/presentations/2026-spring-briefing/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-spring-briefing

--- a/docs/fixtures/reference-project/content/presentations/index.yaml
+++ b/docs/fixtures/reference-project/content/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-spring-briefing
@@ -9,8 +10,6 @@ presentations:
     summary: Reliability work, platform roadmap, and team highlights for the first half of spring.
     published: true
     featured: true
-    presentation_path: presentations/2026-spring-briefing/presentation.yaml
-    generated_path: presentations/2026-spring-briefing/generated.yaml
   - id: 2025-winter-summary
     presentation_path: presentations/2025-winter-summary/presentation.yaml
     generated_path: presentations/2025-winter-summary/generated.yaml
@@ -20,5 +19,3 @@ presentations:
     summary: Earlier update used for archive navigation examples in the docs.
     published: true
     featured: false
-    presentation_path: presentations/2025-winter-summary/presentation.yaml
-    generated_path: presentations/2025-winter-summary/generated.yaml

--- a/docs/fixtures/reference-project/content/site.yaml
+++ b/docs/fixtures/reference-project/content/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Acorn Cloud Updates

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,7 +19,7 @@ This creates a common `content/` layout with:
 - `presentations/<id>/presentation.yaml` - slides and content
 - `presentations/<id>/generated.yaml` - generated data (metrics, releases, contributors)
 
-Each of these files declares a major `schemaVersion` (currently `1`) at the top level. See the [schema reference](/schema/) for details.
+Each of these files declares a major `schemaVersion` (currently `1`) at the top level and includes a JSON Schema comment for editor validation. See the [schema reference](/schema/) for details.
 
 The scaffold uses a conventional folder layout, but the registry points to presentation files explicitly.
 

--- a/docs/schema/generated.md
+++ b/docs/schema/generated.md
@@ -6,6 +6,13 @@ For a complete example, see the [reference generated.yaml](https://github.com/lr
 
 ## Top level
 
+```yaml
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
+schemaVersion: 1
+generated:
+  id: 2026-spring-briefing
+```
+
 | Field | Required | Type | Description |
 | --- | --- | --- | --- |
 | `schemaVersion` | yes | number | Major schema version. Must be `1` for this Slide Spec release. |
@@ -60,7 +67,7 @@ generated:
 
 ## `generated.releases`
 
-Required array of release objects. The validator only checks that `releases` is an array; it does not validate the shape of each release entry beyond normal downstream use.
+Required array of release objects.
 
 ### `generated.releases[]`
 
@@ -83,8 +90,6 @@ Required array of release objects. The validator only checks that `releases` is 
 
 ### `generated.contributors.authors[]`
 
-The validator checks that `authors` is an array. It does not validate the shape of each author entry beyond the fields consumed by the app and CLI.
-
 | Field | Required | Type | Notes |
 | --- | --- | --- | --- |
 | `login` | yes | string | GitHub username or handle. Used for profile links and contributor matching. |
@@ -95,7 +100,7 @@ The validator checks that `authors` is an array. It does not validate the shape 
 
 ## `generated.merged_prs`
 
-Optional. If present, it must be an array. The validator does not inspect the individual entries beyond the array check.
+Optional. If present, it must be an array of merged pull request entries.
 
 ### `generated.merged_prs[]`
 

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -13,4 +13,31 @@ A Slide Spec project uses four YAML files (only the `.yaml` extension is support
 
 Each file starts with a major `schemaVersion` field (currently `1`) so future tooling can detect incompatible documents without guessing from structure alone.
 
+## Editor JSON Schema
+
+Scaffolded YAML files include a `yaml-language-server` schema comment for editor validation and autocomplete:
+
+```yaml
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
+schemaVersion: 1
+```
+
+The public JSON Schemas are maintained to mirror Slide Spec runtime validation and make editors more useful while you author content. Use `slide-spec validate` as the authoritative project validation path before publishing.
+
+Use the specific schema for each file when you know the document type:
+
+| File | Schema URL |
+| --- | --- |
+| `content/site.yaml` | `https://slide-spec.dev/schema/site.schema.json` |
+| `content/presentations/index.yaml` | `https://slide-spec.dev/schema/presentations-index.schema.json` |
+| `content/presentations/<id>/presentation.yaml` | `https://slide-spec.dev/schema/presentation.schema.json` |
+| `content/presentations/<id>/generated.yaml` | `https://slide-spec.dev/schema/generated.schema.json` |
+
+For hand-authored files where the type is not known yet, use the dispatcher schema:
+
+```yaml
+# yaml-language-server: $schema=https://slide-spec.dev/schema.json
+schemaVersion: 1
+```
+
 Read in order: [site.yaml](/schema/site) → [presentations/index.yaml](/schema/presentations-index) → [presentation.yaml](/schema/presentation) → [generated.yaml](/schema/generated).

--- a/docs/schema/presentation.md
+++ b/docs/schema/presentation.md
@@ -8,6 +8,13 @@ Each slide owns its own `content` block. If two slides need the same copy or lab
 
 ## Top level
 
+```yaml
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
+schemaVersion: 1
+presentation:
+  id: 2026-spring-briefing
+```
+
 | Field | Required | Type | Description |
 | --- | --- | --- | --- |
 | `schemaVersion` | yes | number | Major schema version. Must be `1` for this Slide Spec release. |

--- a/docs/schema/presentations-index.md
+++ b/docs/schema/presentations-index.md
@@ -5,6 +5,7 @@ Controls what appears on the presentations list page.
 ## Example
 
 ```yaml
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-spring-briefing

--- a/docs/schema/site.md
+++ b/docs/schema/site.md
@@ -5,6 +5,7 @@ Global branding, navigation labels, footer links, and page copy.
 ## Minimal example
 
 ```yaml
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: My Project Updates
@@ -124,6 +125,7 @@ At least one of `label` or `fa_icon` must be present.
 | `home_label` | string |
 | `presentations_label` | string |
 | `latest_presentation_label` | string |
+| `docs_enabled` | boolean |
 | `toggle_label` | string |
 
 All fields optional.

--- a/examples/community-update/content/presentations/2026-q1-community/generated.yaml
+++ b/examples/community-update/content/presentations/2026-q1-community/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1-community

--- a/examples/community-update/content/presentations/2026-q1-community/presentation.yaml
+++ b/examples/community-update/content/presentations/2026-q1-community/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1-community

--- a/examples/community-update/content/presentations/index.yaml
+++ b/examples/community-update/content/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-q1-community

--- a/examples/community-update/content/site.yaml
+++ b/examples/community-update/content/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Prism Community Updates

--- a/examples/open-source-update/content/presentations/2026-q1-update/generated.yaml
+++ b/examples/open-source-update/content/presentations/2026-q1-update/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1-update

--- a/examples/open-source-update/content/presentations/2026-q1-update/presentation.yaml
+++ b/examples/open-source-update/content/presentations/2026-q1-update/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1-update

--- a/examples/open-source-update/content/presentations/index.yaml
+++ b/examples/open-source-update/content/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-q1-update

--- a/examples/open-source-update/content/site.yaml
+++ b/examples/open-source-update/content/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Vortex CLI Updates

--- a/examples/product-review/content/presentations/2026-q1-review/generated.yaml
+++ b/examples/product-review/content/presentations/2026-q1-review/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1-review

--- a/examples/product-review/content/presentations/2026-q1-review/presentation.yaml
+++ b/examples/product-review/content/presentations/2026-q1-review/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1-review

--- a/examples/product-review/content/presentations/index.yaml
+++ b/examples/product-review/content/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-q1-review

--- a/examples/product-review/content/site.yaml
+++ b/examples/product-review/content/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Meridian Product Reviews

--- a/examples/security-posture/content/presentations/2026-q1-posture/generated.yaml
+++ b/examples/security-posture/content/presentations/2026-q1-posture/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-q1-posture

--- a/examples/security-posture/content/presentations/2026-q1-posture/presentation.yaml
+++ b/examples/security-posture/content/presentations/2026-q1-posture/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-q1-posture

--- a/examples/security-posture/content/presentations/index.yaml
+++ b/examples/security-posture/content/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-q1-posture

--- a/examples/security-posture/content/site.yaml
+++ b/examples/security-posture/content/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Sentinel Security Reports

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -9,11 +9,14 @@
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.5.2",
         "@vitest/coverage-v8": "^4.1.2",
+        "ajv": "^8.18.0",
         "eslint": "^10.2.0",
         "globals": "^17.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.0"
+        "vitest": "^4.1.0",
+        "yaml": "^2.8.3",
+        "yaml-language-server": "^1.21.0"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -1055,6 +1058,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1079,20 +1089,35 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/assertion-error": {
@@ -1315,6 +1340,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
@@ -1419,6 +1468,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1651,9 +1717,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -1661,6 +1727,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2199,6 +2272,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2207,6 +2296,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -2624,6 +2730,85 @@
         }
       }
     },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2665,6 +2850,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.21.0.tgz",
+      "integrity": "sha512-fpDEAF7s0mO9e7xbi/retaN5P6wpbHDBszLsogiWNZ+F4CQ0QFBoGI4QbPZwoMmel6av6Pq+LPeKNZYljgu28w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "prettier": "^3.8.1",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.7.1"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
       }
     },
     "node_modules/yocto-queue": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -14,14 +14,22 @@
     "verify": "npm run lint && npm run typecheck && npm run coverage",
     "verify:ci": "npm run lint && npm run typecheck && npm run coverage"
   },
+  "overrides": {
+    "yaml-language-server": {
+      "yaml": "^2.8.3"
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.5.2",
     "@vitest/coverage-v8": "^4.1.2",
+    "ajv": "^8.18.0",
     "eslint": "^10.2.0",
     "globals": "^17.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.58.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "yaml": "^2.8.3",
+    "yaml-language-server": "^1.21.0"
   }
 }

--- a/shared/src/content-validator.spec.ts
+++ b/shared/src/content-validator.spec.ts
@@ -105,9 +105,35 @@ const validGeneratedDocument = {
         metadata: { comparison_status: 'complete', warning_codes: [] },
       },
     },
-    releases: [],
-    contributors: { total: 0, authors: [] },
-    merged_prs: [],
+    releases: [
+      {
+        id: 'v1.0.0',
+        version: 'v1.0.0',
+        published_at: '2026-01-31T00:00:00Z',
+        url: 'https://github.com/lreading/slide-spec/releases/tag/v1.0.0',
+        summary_bullets: ['First release'],
+      },
+    ],
+    contributors: {
+      total: 1,
+      authors: [
+        {
+          login: 'octocat',
+          name: 'Octocat',
+          avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+          merged_prs: 2,
+          first_time: true,
+        },
+      ],
+    },
+    merged_prs: [
+      {
+        number: 42,
+        title: 'Ship launch content',
+        merged_at: '2026-01-30T00:00:00Z',
+        author_login: 'octocat',
+      },
+    ],
   },
 } satisfies { schemaVersion: number, generated: GeneratedPresentationData }
 
@@ -339,6 +365,21 @@ describe('ContentValidator', () => {
         generated: { ...validGeneratedDocument.generated, merged_prs: 'not an array' },
       }),
     ).toThrow('generated document.generated.merged_prs must be an array.')
+    expect(() =>
+      validator.validateGeneratedDocument({
+        schemaVersion: SLIDE_SPEC_SCHEMA_VERSION,
+        generated: { ...validGeneratedDocument.generated, releases: [{ id: 'v1.0.0' }] },
+      }),
+    ).toThrow('generated document.generated.releases[0].version must be a string.')
+    expect(() =>
+      validator.validateGeneratedDocument({
+        schemaVersion: SLIDE_SPEC_SCHEMA_VERSION,
+        generated: {
+          ...validGeneratedDocument.generated,
+          contributors: { total: 1, authors: [{ login: 'octocat' }] },
+        },
+      }),
+    ).toThrow('generated document.generated.contributors.authors[0].name must be a string.')
   })
 
   it('rejects inconsistent presentation ids', () => {

--- a/shared/src/content-validator.ts
+++ b/shared/src/content-validator.ts
@@ -36,6 +36,7 @@ interface GeneratedDocument {
 
 function assertLink(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['label', 'url', 'eyebrow'], path)
   assertNonBlankString(value.label, `${path}.label`)
   assertNonBlankString(value.url, `${path}.url`)
   assertOptionalString(value.eyebrow, `${path}.eyebrow`)
@@ -43,6 +44,7 @@ function assertLink(value: unknown, path: string): void {
 
 function assertProjectBadge(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['label', 'fa_icon', 'icon_position'], path)
   assertOptionalString(value.label, `${path}.label`)
   assertOptionalString(value.fa_icon, `${path}.fa_icon`)
   assertOptionalString(value.icon_position, `${path}.icon_position`)
@@ -54,6 +56,7 @@ function assertProjectBadge(value: unknown, path: string): void {
 
 function assertPresentationLogo(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['url', 'alt'], path)
   assertOptionalString(value.url, `${path}.url`)
   assertOptionalString(value.alt, `${path}.alt`)
   assert(value.url !== undefined || value.alt === undefined, `${path}.alt requires ${path}.url.`)
@@ -61,6 +64,7 @@ function assertPresentationLogo(value: unknown, path: string): void {
 
 function assertMascotContent(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['url', 'alt'], path)
   assertOptionalString(value.url, `${path}.url`)
   assertOptionalString(value.alt, `${path}.alt`)
   assert(value.url !== undefined || value.alt === undefined, `${path}.alt requires ${path}.url.`)
@@ -68,6 +72,7 @@ function assertMascotContent(value: unknown, path: string): void {
 
 function assertSiteMetadata(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['title', 'description', 'image_url', 'image_alt'], path)
   assertOptionalString(value.title, `${path}.title`)
   assertOptionalString(value.description, `${path}.description`)
   assertOptionalString(value.image_url, `${path}.image_url`)
@@ -77,6 +82,7 @@ function assertSiteMetadata(value: unknown, path: string): void {
 
 function assertDataSource(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['type', 'url'], path)
   assertNonBlankString(value.type, `${path}.type`)
   assert(value.type === 'github', `${path}.type must be "github".`)
   assertNonBlankString(value.url, `${path}.url`)
@@ -103,6 +109,7 @@ function assertOptionalUrlString(value: unknown, path: string): void {
 
 function assertNavigationContent(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['brand_title', 'home_label', 'presentations_label', 'latest_presentation_label', 'docs_enabled', 'toggle_label'], path)
   assertOptionalString(value.brand_title, `${path}.brand_title`)
   assertOptionalString(value.home_label, `${path}.home_label`)
   assertOptionalString(value.presentations_label, `${path}.presentations_label`)
@@ -115,6 +122,7 @@ function assertNavigationContent(value: unknown, path: string): void {
 
 function assertAppFooterContent(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['repository_label', 'repository_url'], path)
   assertOptionalString(value.repository_label, `${path}.repository_label`)
   assertOptionalString(value.repository_url, `${path}.repository_url`)
   assert(
@@ -126,6 +134,7 @@ function assertAppFooterContent(value: unknown, path: string): void {
 
 function assertAttributionContent(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['enabled', 'label', 'url'], path)
   if (value.enabled !== undefined) {
     assertBoolean(value.enabled, `${path}.enabled`)
   }
@@ -140,11 +149,25 @@ function assertAttributionContent(value: unknown, path: string): void {
 
 function assertPresentationChromeContent(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['mark_label'], path)
   assertOptionalString(value.mark_label, `${path}.mark_label`)
 }
 
 function assertPresentationToolbarContent(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(
+    value,
+    [
+      'navigation_label',
+      'previous_slide_label',
+      'next_slide_label',
+      'presentation_mode_label',
+      'shortcut_help_title',
+      'shortcut_help_body',
+      'shortcut_help_dismiss_label',
+    ],
+    path,
+  )
   assertOptionalString(value.navigation_label, `${path}.navigation_label`)
   assertOptionalString(value.previous_slide_label, `${path}.previous_slide_label`)
   assertOptionalString(value.next_slide_label, `${path}.next_slide_label`)
@@ -156,6 +179,7 @@ function assertPresentationToolbarContent(value: unknown, path: string): void {
 
 function assertHomeHeroContent(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['title_primary', 'title_accent', 'subtitle'], path)
   assertOptionalString(value.title_primary, `${path}.title_primary`)
   assertOptionalString(value.title_accent, `${path}.title_accent`)
   assertOptionalString(value.subtitle, `${path}.subtitle`)
@@ -163,6 +187,28 @@ function assertHomeHeroContent(value: unknown, path: string): void {
 
 function assertPresentationsPageContent(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(
+    value,
+    [
+      'title',
+      'search_label',
+      'search_placeholder',
+      'year_label',
+      'all_years_label',
+      'open_presentation_label',
+      'empty_title',
+      'empty_message',
+      'previous_page_label',
+      'next_page_label',
+      'page_label',
+      'page_of_label',
+      'showing_label',
+      'total_label',
+      'presentation_singular_label',
+      'presentation_plural_label',
+    ],
+    path,
+  )
   assertOptionalString(value.title, `${path}.title`)
   assertOptionalString(value.search_label, `${path}.search_label`)
   assertOptionalString(value.search_placeholder, `${path}.search_placeholder`)
@@ -183,17 +229,48 @@ function assertPresentationsPageContent(value: unknown, path: string): void {
 
 function assertMetricValue(value: unknown, path: string): asserts value is MetricValue {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['label', 'current', 'previous', 'delta', 'metadata'], path)
   assertNonBlankString(value.label, `${path}.label`)
   assertNumber(value.current, `${path}.current`)
   assertNumber(value.previous, `${path}.previous`)
   assertNumber(value.delta, `${path}.delta`)
   assert(isRecord(value.metadata), `${path}.metadata must be an object.`)
+  assertNoUnexpectedKeys(value.metadata, ['comparison_status', 'warning_codes'], `${path}.metadata`)
   assertNonBlankString(value.metadata.comparison_status, `${path}.metadata.comparison_status`)
   assert(
     ['complete', 'partial', 'skipped', 'unavailable'].includes(value.metadata.comparison_status),
     `${path}.metadata.comparison_status must be one of complete, partial, skipped, or unavailable.`,
   )
   assertStringArray(value.metadata.warning_codes, `${path}.metadata.warning_codes`)
+}
+
+function assertReleaseEntry(value: unknown, path: string): void {
+  assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['id', 'version', 'published_at', 'url', 'summary_bullets'], path)
+  assertNonBlankString(value.id, `${path}.id`)
+  assertNonBlankString(value.version, `${path}.version`)
+  assertNonBlankString(value.published_at, `${path}.published_at`)
+  assertNonBlankString(value.url, `${path}.url`)
+  assertStringArray(value.summary_bullets, `${path}.summary_bullets`)
+}
+
+function assertContributorEntry(value: unknown, path: string): void {
+  assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['login', 'name', 'avatar_url', 'merged_prs', 'first_time'], path)
+  assertNonBlankString(value.login, `${path}.login`)
+  assertNonBlankString(value.name, `${path}.name`)
+  assertNonBlankString(value.avatar_url, `${path}.avatar_url`)
+  assertNumber(value.merged_prs, `${path}.merged_prs`)
+  assertBoolean(value.first_time, `${path}.first_time`)
+}
+
+function assertMergedPullRequestEntry(value: unknown, path: string): void {
+  assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['number', 'title', 'merged_at', 'author_login'], path)
+  assertNumber(value.number, `${path}.number`)
+  assertNonBlankString(value.title, `${path}.title`)
+  assertNonBlankString(value.merged_at, `${path}.merged_at`)
+  assertNonBlankString(value.author_login, `${path}.author_login`)
 }
 
 function validateSlide(value: unknown, path: string): void {
@@ -227,6 +304,31 @@ export class ContentValidator {
     assertSchemaVersion(document.schemaVersion, 'site.yaml.schemaVersion')
     assert(isRecord(document.site), 'site.yaml.site must be an object.')
     const site = document.site
+    assertNoUnexpectedKeys(
+      site,
+      [
+        'title',
+        'deployment_url',
+        'sitemap_enabled',
+        'metadata',
+        'mascot',
+        'data_sources',
+        'project_badge',
+        'presentation_logo',
+        'navigation',
+        'app_footer',
+        'attribution',
+        'presentation_chrome',
+        'presentation_toolbar',
+        'home_hero',
+        'home_intro',
+        'home_cta_label',
+        'presentations_cta_label',
+        'presentations_page',
+        'links',
+      ],
+      'site.yaml.site',
+    )
     assertNonBlankString(site.title, 'site.yaml.site.title')
     assertOptionalUrlString(site.deployment_url, 'site.yaml.site.deployment_url')
     if (site.sitemap_enabled !== undefined) {
@@ -276,6 +378,11 @@ export class ContentValidator {
     ;(document.presentations as unknown[]).forEach((entry, index) => {
       const path = `presentations/index.yaml.presentations[${index}]`
       assert(isRecord(entry), `${path} must be an object.`)
+      assertNoUnexpectedKeys(
+        entry,
+        ['id', 'year', 'title', 'subtitle', 'summary', 'presentation_path', 'generated_path', 'published', 'featured'],
+        path,
+      )
       assertNonBlankString(entry.id, `${path}.id`)
       const id = entry.id
       assert(!ids.has(id), `${path}.id must be unique.`)
@@ -320,19 +427,32 @@ export class ContentValidator {
     assertSchemaVersion(document.schemaVersion, 'generated document.schemaVersion')
     assert(isRecord(document.generated), 'generated document.generated must be an object.')
     const generated = document.generated
+    assertNoUnexpectedKeys(
+      generated,
+      ['id', 'period', 'previous_presentation_id', 'stats', 'releases', 'contributors', 'merged_prs'],
+      'generated document.generated',
+    )
     assertNonBlankString(generated.id, 'generated document.generated.id')
     assert(isRecord(generated.period), 'generated document.generated.period must be an object.')
+    assertNoUnexpectedKeys(generated.period, ['start', 'end'], 'generated document.generated.period')
     assertNonBlankString(generated.period.start, 'generated document.generated.period.start')
     assertNonBlankString(generated.period.end, 'generated document.generated.period.end')
     assertOptionalString(generated.previous_presentation_id, 'generated document.generated.previous_presentation_id')
     assert(isRecord(generated.stats), 'generated document.generated.stats must be an object.')
     Object.entries(generated.stats).forEach(([key, value]) => assertMetricValue(value, `generated document.generated.stats.${key}`))
     assert(Array.isArray(generated.releases), 'generated document.generated.releases must be an array.')
+    ;(generated.releases as unknown[]).forEach((release, index) =>
+      assertReleaseEntry(release, `generated document.generated.releases[${index}]`))
     assert(isRecord(generated.contributors), 'generated document.generated.contributors must be an object.')
+    assertNoUnexpectedKeys(generated.contributors, ['total', 'authors'], 'generated document.generated.contributors')
     assertNumber(generated.contributors.total, 'generated document.generated.contributors.total')
     assert(Array.isArray(generated.contributors.authors), 'generated document.generated.contributors.authors must be an array.')
+    ;(generated.contributors.authors as unknown[]).forEach((author, index) =>
+      assertContributorEntry(author, `generated document.generated.contributors.authors[${index}]`))
     if (generated.merged_prs !== undefined) {
       assert(Array.isArray(generated.merged_prs), 'generated document.generated.merged_prs must be an array.')
+      ;(generated.merged_prs as unknown[]).forEach((pullRequest, index) =>
+        assertMergedPullRequestEntry(pullRequest, `generated document.generated.merged_prs[${index}]`))
     }
   }
 

--- a/shared/src/json-schema-urls.ts
+++ b/shared/src/json-schema-urls.ts
@@ -1,0 +1,9 @@
+export const SLIDE_SPEC_SCHEMA_BASE_URL = 'https://slide-spec.dev' as const
+
+export const slideSpecSchemaUrls = {
+  generated: `${SLIDE_SPEC_SCHEMA_BASE_URL}/schema/generated.schema.json`,
+  presentation: `${SLIDE_SPEC_SCHEMA_BASE_URL}/schema/presentation.schema.json`,
+  presentationsIndex: `${SLIDE_SPEC_SCHEMA_BASE_URL}/schema/presentations-index.schema.json`,
+  root: `${SLIDE_SPEC_SCHEMA_BASE_URL}/schema.json`,
+  site: `${SLIDE_SPEC_SCHEMA_BASE_URL}/schema/site.schema.json`,
+} as const

--- a/shared/src/json-schema.spec.ts
+++ b/shared/src/json-schema.spec.ts
@@ -1,0 +1,204 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { resolve, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import Ajv2020 from 'ajv/dist/2020'
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+import { ContentValidator } from './content-validator'
+import { slideSpecSchemaUrls } from './json-schema-urls'
+
+const repoRoot = resolve(fileURLToPath(new URL('.', import.meta.url)), '..', '..')
+const publicSchemaRoot = resolve(repoRoot, 'slides', 'public')
+const schemaIds = slideSpecSchemaUrls
+
+interface FixtureDocument {
+  path: string
+  document: unknown
+  schemaId: string
+}
+
+const fixtureRoots = [
+  'app/e2e/fixtures',
+  'cli/examples-synced',
+  'content',
+  'docs/fixtures',
+  'examples',
+  'slides/content',
+]
+
+async function collectYamlFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = await Promise.all(entries.map(async (entry) => {
+    const entryPath = resolve(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      return collectYamlFiles(entryPath)
+    }
+
+    return entry.isFile() && entry.name.endsWith('.yaml') ? [entryPath] : []
+  }))
+
+  return files.flat()
+}
+
+async function loadSchemas(): Promise<Ajv2020> {
+  const ajv = new Ajv2020({ allErrors: true })
+  const schemaPaths = [
+    'schema.json',
+    'schema/defs.schema.json',
+    'schema/site.schema.json',
+    'schema/presentations-index.schema.json',
+    'schema/presentation.schema.json',
+    'schema/generated.schema.json',
+  ]
+
+  for (const schemaPath of schemaPaths) {
+    ajv.addSchema(JSON.parse(await readFile(resolve(publicSchemaRoot, schemaPath), 'utf8')))
+  }
+
+  return ajv
+}
+
+async function loadFixtureDocuments(): Promise<FixtureDocument[]> {
+  const files = (await Promise.all(
+    fixtureRoots.map((fixtureRoot) => collectYamlFiles(resolve(repoRoot, fixtureRoot))),
+  )).flat()
+  const documents: FixtureDocument[] = []
+
+  for (const file of files) {
+    documents.push({
+      path: relative(repoRoot, file),
+      document: parse(await readFile(file, 'utf8')),
+      schemaId: resolveSchemaId(file),
+    })
+  }
+
+  return documents.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+function resolveSchemaId(path: string): string {
+  if (path.endsWith('/site.yaml')) return schemaIds.site
+  if (path.endsWith('/presentations/index.yaml')) return schemaIds.presentationsIndex
+  if (path.endsWith('/presentation.yaml')) return schemaIds.presentation
+  if (path.endsWith('/generated.yaml')) return schemaIds.generated
+  throw new Error(`No Slide Spec schema mapping for ${path}.`)
+}
+
+function validateDocument(ajv: Ajv2020, schemaId: string, document: unknown): string[] {
+  const validate = ajv.getSchema(schemaId)
+  if (!validate) throw new Error(`Missing compiled schema ${schemaId}.`)
+
+  return validate(document)
+    ? []
+    : (validate.errors ?? []).map((error) => `${error.instancePath || '/'} ${error.message ?? 'failed validation'}`)
+}
+
+function validateRuntimeDocument(validator: ContentValidator, fixture: FixtureDocument): void {
+  if (fixture.schemaId === schemaIds.site) {
+    validator.validateSiteDocument(fixture.document)
+    return
+  }
+
+  if (fixture.schemaId === schemaIds.presentationsIndex) {
+    validator.validatePresentationIndexDocument(fixture.document)
+    return
+  }
+
+  if (fixture.schemaId === schemaIds.presentation) {
+    validator.validatePresentationDocument(fixture.document)
+    return
+  }
+
+  if (fixture.schemaId === schemaIds.generated) {
+    validator.validateGeneratedDocument(fixture.document)
+  }
+}
+
+describe('public JSON Schemas', () => {
+  it('validate every known YAML fixture against its specific schema and the dispatcher', async () => {
+    const ajv = await loadSchemas()
+    const failures: string[] = []
+
+    for (const fixture of await loadFixtureDocuments()) {
+      for (const schemaId of [fixture.schemaId, schemaIds.root]) {
+        const errors = validateDocument(ajv, schemaId, fixture.document)
+        if (errors.length > 0) {
+          failures.push(`${fixture.path} against ${schemaId}:\n${errors.join('\n')}`)
+        }
+      }
+    }
+
+    expect(failures).toEqual([])
+  })
+
+  it('keeps the fixture corpus aligned with runtime content validation', async () => {
+    const validator = new ContentValidator()
+    const failures: string[] = []
+
+    for (const fixture of await loadFixtureDocuments()) {
+      try {
+        validateRuntimeDocument(validator, fixture)
+      } catch (error) {
+        failures.push(`${fixture.path}: ${error instanceof Error ? error.message : String(error)}`)
+      }
+    }
+
+    expect(failures).toEqual([])
+  })
+
+  it('rejects schema version and template/content mismatches', async () => {
+    const ajv = await loadSchemas()
+    const invalidDocuments = [
+      {
+        schemaId: schemaIds.site,
+        document: { schemaVersion: 2, site: {} },
+      },
+      {
+        schemaId: schemaIds.presentation,
+        document: {
+          schemaVersion: 1,
+          presentation: {
+            id: 'demo',
+            title: 'Demo',
+            subtitle: 'Example',
+            slides: [{ template: 'agenda', enabled: true, title: 'Agenda', content: { extra: true } }],
+          },
+        },
+      },
+      {
+        schemaId: schemaIds.presentation,
+        document: {
+          schemaVersion: 1,
+          presentation: {
+            id: 'demo',
+            title: 'Demo',
+            subtitle: 'Example',
+            slides: [{ template: 'hero', enabled: true, content: { subtitle_prefix: 'Only subtitle' } }],
+          },
+        },
+      },
+      {
+        schemaId: schemaIds.generated,
+        document: {
+          schemaVersion: 1,
+          generated: {
+            id: 'demo',
+            period: { start: '2026-01-01', end: '2026-03-31' },
+            stats: {},
+            releases: [{}],
+            contributors: { total: 0, authors: [] },
+          },
+        },
+      },
+    ]
+
+    expect(invalidDocuments.map(({ schemaId, document }) => validateDocument(ajv, schemaId, document).length > 0)).toEqual([
+      true,
+      true,
+      true,
+      true,
+    ])
+  })
+})

--- a/shared/src/yaml-language-server.spec.ts
+++ b/shared/src/yaml-language-server.spec.ts
@@ -1,0 +1,382 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { createServer } from 'node:http'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const repoRoot = resolve(fileURLToPath(new URL('.', import.meta.url)), '..', '..')
+const publicSchemaRoot = resolve(repoRoot, 'slides', 'public')
+const yamlSettings = {
+  validate: true,
+  schemaStore: { enable: false },
+  schemas: {},
+}
+
+interface JsonRpcMessage {
+  jsonrpc: '2.0'
+  id?: number
+  method?: string
+  params?: unknown
+  result?: unknown
+  error?: unknown
+}
+
+interface Diagnostic {
+  message: string
+}
+
+interface CompletionItem {
+  label: string
+}
+
+interface CompletionList {
+  items: CompletionItem[]
+}
+
+class LocalSchemaServer {
+  private readonly server = createServer((request, response) => {
+    void this.handleRequest(request.url ?? '/')
+      .then((body) => {
+        response.writeHead(200, { 'content-type': 'application/schema+json' })
+        response.end(body)
+      })
+      .catch(() => {
+        response.writeHead(404)
+        response.end('Not found')
+      })
+  })
+
+  private baseUrl = ''
+
+  async start(): Promise<string> {
+    await new Promise<void>((resolveStart) => {
+      this.server.listen(0, '127.0.0.1', resolveStart)
+    })
+
+    const address = this.server.address()
+    if (!address || typeof address === 'string') throw new Error('Schema server did not bind to a TCP port.')
+
+    this.baseUrl = `http://127.0.0.1:${address.port}`
+    return this.baseUrl
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolveStop, reject) => {
+      this.server.close((error) => {
+        if (error) reject(error)
+        else resolveStop()
+      })
+    })
+  }
+
+  private async handleRequest(url: string): Promise<string> {
+    const path = url === '/schema.json' ? 'schema.json' : url.replace(/^\//, '')
+    const body = await readFile(resolve(publicSchemaRoot, path), 'utf8')
+
+    return body.replaceAll('https://slide-spec.dev', this.baseUrl)
+  }
+}
+
+class YamlLanguageServerClient {
+  private readonly child: ChildProcessWithoutNullStreams
+  private buffer = Buffer.alloc(0)
+  private nextId = 1
+  private readonly pending = new Map<number, (message: JsonRpcMessage) => void>()
+  private readonly diagnostics = new Map<string, Diagnostic[]>()
+  private readonly diagnosticsWaiters = new Map<string, Array<(diagnostics: Diagnostic[]) => void>>()
+
+  constructor() {
+    this.child = spawn(resolve(repoRoot, 'shared', 'node_modules', '.bin', languageServerBin()), ['--stdio'], {
+      cwd: resolve(repoRoot, 'shared'),
+    })
+    this.child.stdout.on('data', (chunk: Buffer) => this.handleOutput(chunk))
+  }
+
+  async initialize(): Promise<void> {
+    await this.request('initialize', {
+      processId: process.pid,
+      rootUri: pathToFileURL(repoRoot).toString(),
+      capabilities: {
+        textDocument: {
+          completion: { completionItem: { snippetSupport: false } },
+        },
+        workspace: { configuration: true },
+      },
+      initializationOptions: { schemaStore: { enable: false } },
+    })
+    this.notify('initialized', {})
+    this.notify('workspace/didChangeConfiguration', { settings: { yaml: yamlSettings } })
+  }
+
+  async stop(): Promise<void> {
+    if (!this.child.killed) {
+      await this.request('shutdown', {})
+      this.notify('exit', {})
+    }
+  }
+
+  async openDocumentAndWaitForDiagnostics(uri: string, text: string): Promise<Diagnostic[]> {
+    const diagnosticsPromise = this.waitForDiagnostics(uri)
+    this.notify('textDocument/didOpen', {
+      textDocument: { uri, languageId: 'yaml', version: 1, text },
+    })
+
+    return diagnosticsPromise
+  }
+
+  async completionLabels(uri: string, line: number, character: number): Promise<string[]> {
+    const result = await this.request('textDocument/completion', {
+      textDocument: { uri },
+      position: { line, character },
+    })
+    const items = Array.isArray(result)
+      ? result as CompletionItem[]
+      : (result as CompletionList).items
+
+    return items.map((item) => item.label)
+  }
+
+  private request(method: string, params: unknown): Promise<unknown> {
+    const id = this.nextId
+    this.nextId += 1
+    this.send({ jsonrpc: '2.0', id, method, params })
+
+    return new Promise((resolveRequest, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`Timed out waiting for ${method}.`))
+      }, 5_000)
+
+      this.pending.set(id, (message) => {
+        clearTimeout(timeout)
+        if (message.error) reject(new Error(JSON.stringify(message.error)))
+        else resolveRequest(message.result)
+      })
+    })
+  }
+
+  private notify(method: string, params: unknown): void {
+    this.send({ jsonrpc: '2.0', method, params })
+  }
+
+  private send(message: JsonRpcMessage): void {
+    const body = JSON.stringify(message)
+    this.child.stdin.write(`Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`)
+  }
+
+  private handleOutput(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk])
+
+    while (true) {
+      const headerEnd = this.buffer.indexOf('\r\n\r\n')
+      if (headerEnd === -1) return
+
+      const header = this.buffer.subarray(0, headerEnd).toString('utf8')
+      const contentLength = /Content-Length: (\d+)/iu.exec(header)
+      if (!contentLength) throw new Error(`Missing Content-Length header: ${header}`)
+
+      const bodyStart = headerEnd + 4
+      const bodyEnd = bodyStart + Number(contentLength[1])
+      if (this.buffer.length < bodyEnd) return
+
+      const message = JSON.parse(this.buffer.subarray(bodyStart, bodyEnd).toString('utf8')) as JsonRpcMessage
+      this.buffer = this.buffer.subarray(bodyEnd)
+      this.handleMessage(message)
+    }
+  }
+
+  private handleMessage(message: JsonRpcMessage): void {
+    if (message.id !== undefined && message.method) {
+      this.handleServerRequest(message)
+      return
+    }
+
+    if (message.id !== undefined) {
+      this.pending.get(message.id)?.(message)
+      this.pending.delete(message.id)
+      return
+    }
+
+    if (message.method === 'textDocument/publishDiagnostics') {
+      const params = message.params as { uri: string, diagnostics: Diagnostic[] }
+      this.diagnostics.set(params.uri, params.diagnostics)
+      const waiters = this.diagnosticsWaiters.get(params.uri) ?? []
+      this.diagnosticsWaiters.delete(params.uri)
+      for (const waiter of waiters) waiter(params.diagnostics)
+    }
+  }
+
+  private handleServerRequest(message: JsonRpcMessage): void {
+    if (message.id === undefined) throw new Error(`Server request ${message.method ?? 'unknown'} did not include an id.`)
+
+    if (message.method === 'workspace/configuration') {
+      const params = message.params as { items?: Array<{ section?: string }> }
+      const result = (params.items ?? []).map((item) => item.section === 'yaml' ? yamlSettings : null)
+      this.send({ jsonrpc: '2.0', id: message.id, result })
+      return
+    }
+
+    this.send({ jsonrpc: '2.0', id: message.id, result: null })
+  }
+
+  private waitForDiagnostics(uri: string): Promise<Diagnostic[]> {
+    const existingDiagnostics = this.diagnostics.get(uri)
+    if (existingDiagnostics) return Promise.resolve(existingDiagnostics)
+
+    return new Promise((resolveWait, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error(`Timed out waiting for diagnostics for ${uri}.`))
+      }, 5_000)
+      const waiters = this.diagnosticsWaiters.get(uri) ?? []
+      waiters.push((diagnostics) => {
+        clearTimeout(timeout)
+        resolveWait(diagnostics)
+      })
+      this.diagnosticsWaiters.set(uri, waiters)
+    })
+  }
+}
+
+function languageServerBin(): string {
+  return process.platform === 'win32' ? 'yaml-language-server.cmd' : 'yaml-language-server'
+}
+
+function schemaComment(schemaUrl: string): string {
+  return `# yaml-language-server: $schema=${schemaUrl}`
+}
+
+function documentUri(name: string): string {
+  return pathToFileURL(resolve(repoRoot, `.tmp-yaml-language-server-${name}.yaml`)).toString()
+}
+
+function siteDocument(schemaUrl: string): string {
+  return `${schemaComment(schemaUrl)}
+schemaVersion: 1
+site:
+  title: Demo
+  home_intro: Intro
+  home_cta_label: Start
+  presentations_cta_label: Decks
+  links:
+    repository:
+      label: Repo
+      url: https://example.com/repo
+    docs:
+      label: Docs
+      url: https://example.com/docs
+    community:
+      label: Community
+      url: https://example.com/community
+`
+}
+
+const presentationDocument = (schemaUrl: string): string => `${schemaComment(schemaUrl)}
+schemaVersion: 1
+presentation:
+  id: demo
+  title: Demo
+  subtitle: Example
+  slides:
+    - template: hero
+      enabled: true
+      content:
+        title_primary: Demo
+`
+
+const generatedDocument = (schemaUrl: string): string => `${schemaComment(schemaUrl)}
+schemaVersion: 1
+generated:
+  id: demo
+  period:
+    start: 2026-01-01
+    end: 2026-03-31
+  stats: {}
+  releases:
+    - id: v1
+      version: v1
+      url: https://example.com/releases/v1
+      published_at: 2026-01-15
+      summary_bullets:
+        - Shipped the demo
+  contributors:
+    total: 1
+    authors:
+      - login: leo
+        name: Leo
+        avatar_url: https://example.com/avatar.png
+        merged_prs: 1
+        first_time: false
+`
+
+describe('YAML language server schema integration', () => {
+  let schemaBaseUrl = ''
+  let schemaServer: LocalSchemaServer
+  let languageServer: YamlLanguageServerClient
+
+  beforeAll(async () => {
+    schemaServer = new LocalSchemaServer()
+    schemaBaseUrl = await schemaServer.start()
+    languageServer = new YamlLanguageServerClient()
+    await languageServer.initialize()
+  }, 10_000)
+
+  afterAll(async () => {
+    await languageServer.stop()
+    await schemaServer.stop()
+  }, 10_000)
+
+  it('reports no diagnostics for valid files with yaml-language-server schema comments', async () => {
+    const fixtures: Array<[string, string]> = [
+      ['site-specific', siteDocument(`${schemaBaseUrl}/schema/site.schema.json`)],
+      ['presentation-specific', presentationDocument(`${schemaBaseUrl}/schema/presentation.schema.json`)],
+      ['generated-specific', generatedDocument(`${schemaBaseUrl}/schema/generated.schema.json`)],
+      ['dispatcher', presentationDocument(`${schemaBaseUrl}/schema.json`)],
+    ]
+
+    for (const [name, document] of fixtures) {
+      await expect(languageServer.openDocumentAndWaitForDiagnostics(documentUri(name), document)).resolves.toEqual([])
+    }
+  })
+
+  it('reports diagnostics for schema violations through the editor validation path', async () => {
+    const invalidSite = siteDocument(`${schemaBaseUrl}/schema/site.schema.json`).replace(
+      '  links:',
+      '  surprise: true\n  links:',
+    )
+    const invalidPresentation = presentationDocument(`${schemaBaseUrl}/schema/presentation.schema.json`).replace(
+      'template: hero',
+      'template: nope',
+    )
+    const invalidGenerated = generatedDocument(`${schemaBaseUrl}/schema/generated.schema.json`).replace(
+      '      version: v1\n',
+      '',
+    )
+
+    const invalidFixtures: Array<[string, string]> = [
+      ['invalid-site', invalidSite],
+      ['invalid-presentation', invalidPresentation],
+      ['invalid-generated', invalidGenerated],
+    ]
+
+    for (const [name, document] of invalidFixtures) {
+      const diagnostics = await languageServer.openDocumentAndWaitForDiagnostics(documentUri(name), document)
+      expect(diagnostics.map((diagnostic) => diagnostic.message).join('\n'), name).not.toHaveLength(0)
+    }
+  })
+
+  it('uses the schema comment for YAML key completions', async () => {
+    const uri = documentUri('site-completions')
+    const document = `${schemaComment(`${schemaBaseUrl}/schema/site.schema.json`)}
+schemaVersion: 1
+site:
+  `
+
+    await languageServer.openDocumentAndWaitForDiagnostics(uri, document)
+    const labels = await languageServer.completionLabels(uri, 3, 2)
+
+    expect(labels).toContain('title')
+    expect(labels).toContain('home_intro')
+  })
+})

--- a/slides/content/presentations/2025-community-update-example/generated.yaml
+++ b/slides/content/presentations/2025-community-update-example/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-community-update-example

--- a/slides/content/presentations/2025-community-update-example/presentation.yaml
+++ b/slides/content/presentations/2025-community-update-example/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-community-update-example

--- a/slides/content/presentations/2025-open-source-example/generated.yaml
+++ b/slides/content/presentations/2025-open-source-example/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2025-open-source-example

--- a/slides/content/presentations/2025-open-source-example/presentation.yaml
+++ b/slides/content/presentations/2025-open-source-example/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2025-open-source-example

--- a/slides/content/presentations/2026-launch/generated.yaml
+++ b/slides/content/presentations/2026-launch/generated.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:
   id: 2026-launch

--- a/slides/content/presentations/2026-launch/presentation.yaml
+++ b/slides/content/presentations/2026-launch/presentation.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:
   id: 2026-launch

--- a/slides/content/presentations/index.yaml
+++ b/slides/content/presentations/index.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:
   - id: 2026-launch

--- a/slides/content/site.yaml
+++ b/slides/content/site.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:
   title: Slide Spec

--- a/slides/public/schema.json
+++ b/slides/public/schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://slide-spec.dev/schema.json",
+  "title": "Slide Spec YAML document",
+  "description": "Dispatcher schema for Slide Spec YAML documents. Prefer a specific schema URL when the file type is known.",
+  "oneOf": [
+    { "$ref": "schema/site.schema.json" },
+    { "$ref": "schema/presentations-index.schema.json" },
+    { "$ref": "schema/presentation.schema.json" },
+    { "$ref": "schema/generated.schema.json" }
+  ]
+}

--- a/slides/public/schema/defs.schema.json
+++ b/slides/public/schema/defs.schema.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://slide-spec.dev/schema/defs.schema.json",
+  "title": "Slide Spec shared schema definitions",
+  "$defs": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "nonBlankString": {
+      "type": "string",
+      "pattern": "\\S"
+    },
+    "stringArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonBlankString"
+      }
+    },
+    "link": {
+      "type": "object",
+      "required": ["label", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "label": { "$ref": "#/$defs/nonBlankString" },
+        "url": { "$ref": "#/$defs/nonBlankString" },
+        "eyebrow": { "$ref": "#/$defs/nonBlankString" }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "dependentRequired": {
+        "image_alt": ["image_url"]
+      },
+      "properties": {
+        "title": { "$ref": "#/$defs/nonBlankString" },
+        "description": { "$ref": "#/$defs/nonBlankString" },
+        "image_url": { "$ref": "#/$defs/nonBlankString" },
+        "image_alt": { "$ref": "#/$defs/nonBlankString" }
+      }
+    },
+    "metricValue": {
+      "type": "object",
+      "required": ["label", "current", "previous", "delta", "metadata"],
+      "additionalProperties": false,
+      "properties": {
+        "label": { "$ref": "#/$defs/nonBlankString" },
+        "current": { "type": "number" },
+        "previous": { "type": "number" },
+        "delta": { "type": "number" },
+        "metadata": {
+          "type": "object",
+          "required": ["comparison_status", "warning_codes"],
+          "additionalProperties": false,
+          "properties": {
+            "comparison_status": {
+              "type": "string",
+              "enum": ["complete", "partial", "skipped", "unavailable"]
+            },
+            "warning_codes": { "$ref": "#/$defs/stringArray" }
+          }
+        }
+      }
+    },
+    "releaseEntry": {
+      "type": "object",
+      "required": ["id", "version", "published_at", "url", "summary_bullets"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/$defs/nonBlankString" },
+        "version": { "$ref": "#/$defs/nonBlankString" },
+        "published_at": { "$ref": "#/$defs/nonBlankString" },
+        "url": { "$ref": "#/$defs/nonBlankString" },
+        "summary_bullets": { "$ref": "#/$defs/stringArray" }
+      }
+    },
+    "contributorEntry": {
+      "type": "object",
+      "required": ["login", "name", "avatar_url", "merged_prs", "first_time"],
+      "additionalProperties": false,
+      "properties": {
+        "login": { "$ref": "#/$defs/nonBlankString" },
+        "name": { "$ref": "#/$defs/nonBlankString" },
+        "avatar_url": { "$ref": "#/$defs/nonBlankString" },
+        "merged_prs": { "type": "number" },
+        "first_time": { "type": "boolean" }
+      }
+    },
+    "mergedPullRequestEntry": {
+      "type": "object",
+      "required": ["number", "title", "merged_at", "author_login"],
+      "additionalProperties": false,
+      "properties": {
+        "number": { "type": "number" },
+        "title": { "$ref": "#/$defs/nonBlankString" },
+        "merged_at": { "$ref": "#/$defs/nonBlankString" },
+        "author_login": { "$ref": "#/$defs/nonBlankString" }
+      }
+    },
+    "contentSection": {
+      "type": "object",
+      "required": ["title", "bullets"],
+      "additionalProperties": false,
+      "properties": {
+        "title": { "$ref": "#/$defs/nonBlankString" },
+        "bullets": { "$ref": "#/$defs/stringArray" }
+      }
+    },
+    "roadmapStage": {
+      "type": "object",
+      "required": ["label", "summary"],
+      "additionalProperties": false,
+      "properties": {
+        "label": { "$ref": "#/$defs/nonBlankString" },
+        "summary": { "$ref": "#/$defs/nonBlankString" }
+      }
+    },
+    "roadmapTheme": {
+      "type": "object",
+      "required": ["category", "target"],
+      "additionalProperties": false,
+      "properties": {
+        "category": { "$ref": "#/$defs/nonBlankString" },
+        "target": { "$ref": "#/$defs/nonBlankString" }
+      }
+    },
+    "spotlightEntry": {
+      "type": "object",
+      "required": ["login", "summary"],
+      "additionalProperties": false,
+      "properties": {
+        "login": { "$ref": "#/$defs/nonBlankString" },
+        "summary": { "$ref": "#/$defs/nonBlankString" }
+      }
+    },
+    "communityMention": {
+      "type": "object",
+      "required": ["type", "title"],
+      "additionalProperties": false,
+      "dependentRequired": {
+        "url": ["url_label"],
+        "url_label": ["url"]
+      },
+      "properties": {
+        "type": { "$ref": "#/$defs/nonBlankString" },
+        "title": { "$ref": "#/$defs/nonBlankString" },
+        "url_label": { "$ref": "#/$defs/nonBlankString" },
+        "url": { "$ref": "#/$defs/nonBlankString" }
+      }
+    },
+    "contributionCard": {
+      "type": "object",
+      "required": ["title", "description", "url_label", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "title": { "$ref": "#/$defs/nonBlankString" },
+        "description": { "$ref": "#/$defs/nonBlankString" },
+        "url_label": { "$ref": "#/$defs/nonBlankString" },
+        "url": { "$ref": "#/$defs/nonBlankString" }
+      }
+    }
+  }
+}

--- a/slides/public/schema/generated.schema.json
+++ b/slides/public/schema/generated.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://slide-spec.dev/schema/generated.schema.json",
+  "title": "Slide Spec generated.yaml",
+  "type": "object",
+  "required": ["schemaVersion", "generated"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "$ref": "defs.schema.json#/$defs/schemaVersion" },
+    "generated": {
+      "type": "object",
+      "required": ["id", "period", "stats", "releases", "contributors"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "period": {
+          "type": "object",
+          "required": ["start", "end"],
+          "additionalProperties": false,
+          "properties": {
+            "start": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+            "end": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+          }
+        },
+        "previous_presentation_id": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "stats": {
+          "type": "object",
+          "additionalProperties": { "$ref": "defs.schema.json#/$defs/metricValue" }
+        },
+        "releases": {
+          "type": "array",
+          "items": { "$ref": "defs.schema.json#/$defs/releaseEntry" }
+        },
+        "contributors": {
+          "type": "object",
+          "required": ["total", "authors"],
+          "additionalProperties": false,
+          "properties": {
+            "total": { "type": "number" },
+            "authors": {
+              "type": "array",
+              "items": { "$ref": "defs.schema.json#/$defs/contributorEntry" }
+            }
+          }
+        },
+        "merged_prs": {
+          "type": "array",
+          "items": { "$ref": "defs.schema.json#/$defs/mergedPullRequestEntry" }
+        }
+      }
+    }
+  }
+}

--- a/slides/public/schema/presentation.schema.json
+++ b/slides/public/schema/presentation.schema.json
@@ -1,0 +1,292 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://slide-spec.dev/schema/presentation.schema.json",
+  "title": "Slide Spec presentation.yaml",
+  "type": "object",
+  "required": ["schemaVersion", "presentation"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "$ref": "defs.schema.json#/$defs/schemaVersion" },
+    "presentation": {
+      "type": "object",
+      "required": ["id", "title", "subtitle", "slides"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "year": { "type": "number" },
+        "title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "subtitle": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "slides": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "$ref": "#/$defs/heroSlide" },
+              { "$ref": "#/$defs/agendaSlide" },
+              { "$ref": "#/$defs/sectionListGridSlide" },
+              { "$ref": "#/$defs/timelineSlide" },
+              { "$ref": "#/$defs/progressTimelineSlide" },
+              { "$ref": "#/$defs/peopleSlide" },
+              { "$ref": "#/$defs/metricsAndLinksSlide" },
+              { "$ref": "#/$defs/actionCardsSlide" },
+              { "$ref": "#/$defs/closingSlide" }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "slideBase": {
+      "type": "object",
+      "required": ["template", "enabled"],
+      "additionalProperties": false,
+      "properties": {
+        "template": {
+          "enum": [
+            "hero",
+            "agenda",
+            "section-list-grid",
+            "timeline",
+            "progress-timeline",
+            "people",
+            "metrics-and-links",
+            "action-cards",
+            "closing"
+          ]
+        },
+        "enabled": { "type": "boolean" },
+        "title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "subtitle": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "content": { "type": "object" }
+      }
+    },
+    "heroSlide": {
+      "allOf": [
+        { "$ref": "#/$defs/slideBase" },
+        {
+          "type": "object",
+          "required": ["template", "enabled", "content"],
+          "properties": {
+            "template": { "const": "hero" },
+            "content": {
+              "type": "object",
+              "additionalProperties": false,
+              "anyOf": [
+                { "required": ["title_primary"] },
+                { "required": ["title_accent"] }
+              ],
+              "properties": {
+                "title_primary": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "title_accent": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "subtitle_prefix": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "quote": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "agendaSlide": {
+      "allOf": [
+        { "$ref": "#/$defs/slideBase" },
+        {
+          "type": "object",
+          "required": ["template", "enabled", "title"],
+          "properties": {
+            "template": { "const": "agenda" },
+            "content": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          }
+        }
+      ]
+    },
+    "sectionListGridSlide": {
+      "allOf": [
+        { "$ref": "#/$defs/slideBase" },
+        {
+          "type": "object",
+          "required": ["template", "enabled", "title", "content"],
+          "properties": {
+            "template": { "const": "section-list-grid" },
+            "content": {
+              "type": "object",
+              "required": ["sections"],
+              "additionalProperties": false,
+              "properties": {
+                "sections": {
+                  "type": "array",
+                  "items": { "$ref": "defs.schema.json#/$defs/contentSection" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "timelineSlide": {
+      "allOf": [
+        { "$ref": "#/$defs/slideBase" },
+        {
+          "type": "object",
+          "required": ["template", "enabled", "title", "content"],
+          "properties": {
+            "template": { "const": "timeline" },
+            "content": {
+              "type": "object",
+              "required": ["featured_release_ids"],
+              "additionalProperties": false,
+              "properties": {
+                "latest_badge_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "footer_link_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "empty_state_title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "empty_state_message": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "featured_release_ids": { "$ref": "defs.schema.json#/$defs/stringArray" }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "progressTimelineSlide": {
+      "allOf": [
+        { "$ref": "#/$defs/slideBase" },
+        {
+          "type": "object",
+          "required": ["template", "enabled", "title", "content"],
+          "properties": {
+            "template": { "const": "progress-timeline" },
+            "content": {
+              "type": "object",
+              "required": ["stage", "stages", "items", "themes"],
+              "additionalProperties": false,
+              "properties": {
+                "stage": { "enum": ["completed", "in-progress", "planned", "future"] },
+                "deliverables_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "focus_areas_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "footer_link_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "stages": {
+                  "type": "object",
+                  "required": ["completed", "in-progress", "planned", "future"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "completed": { "$ref": "defs.schema.json#/$defs/roadmapStage" },
+                    "in-progress": { "$ref": "defs.schema.json#/$defs/roadmapStage" },
+                    "planned": { "$ref": "defs.schema.json#/$defs/roadmapStage" },
+                    "future": { "$ref": "defs.schema.json#/$defs/roadmapStage" }
+                  }
+                },
+                "items": { "$ref": "defs.schema.json#/$defs/stringArray" },
+                "themes": {
+                  "type": "array",
+                  "items": { "$ref": "defs.schema.json#/$defs/roadmapTheme" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "peopleSlide": {
+      "allOf": [
+        { "$ref": "#/$defs/slideBase" },
+        {
+          "type": "object",
+          "required": ["template", "enabled", "title", "content"],
+          "properties": {
+            "template": { "const": "people" },
+            "content": {
+              "type": "object",
+              "required": ["spotlight"],
+              "additionalProperties": false,
+              "properties": {
+                "banner_prefix": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "contributors_link_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "banner_suffix": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "spotlight": {
+                  "type": "array",
+                  "items": { "$ref": "defs.schema.json#/$defs/spotlightEntry" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "metricsAndLinksSlide": {
+      "allOf": [
+        { "$ref": "#/$defs/slideBase" },
+        {
+          "type": "object",
+          "required": ["template", "enabled", "title", "content"],
+          "properties": {
+            "template": { "const": "metrics-and-links" },
+            "content": {
+              "type": "object",
+              "required": ["stat_keys", "mentions"],
+              "additionalProperties": false,
+              "properties": {
+                "section_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "stats_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "show_deltas": { "type": "boolean" },
+                "trend_suffix": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "stat_keys": { "$ref": "defs.schema.json#/$defs/stringArray" },
+                "mentions": {
+                  "type": "array",
+                  "items": { "$ref": "defs.schema.json#/$defs/communityMention" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "actionCardsSlide": {
+      "allOf": [
+        { "$ref": "#/$defs/slideBase" },
+        {
+          "type": "object",
+          "required": ["template", "enabled", "title", "content"],
+          "properties": {
+            "template": { "const": "action-cards" },
+            "content": {
+              "type": "object",
+              "required": ["cards"],
+              "additionalProperties": false,
+              "properties": {
+                "footer_text": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "cards": {
+                  "type": "array",
+                  "items": { "$ref": "defs.schema.json#/$defs/contributionCard" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "closingSlide": {
+      "allOf": [
+        { "$ref": "#/$defs/slideBase" },
+        {
+          "type": "object",
+          "required": ["template", "enabled", "content"],
+          "properties": {
+            "template": { "const": "closing" },
+            "content": {
+              "type": "object",
+              "required": ["heading", "message"],
+              "additionalProperties": false,
+              "properties": {
+                "heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "message": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "quote": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/slides/public/schema/presentations-index.schema.json
+++ b/slides/public/schema/presentations-index.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://slide-spec.dev/schema/presentations-index.schema.json",
+  "title": "Slide Spec presentations/index.yaml",
+  "type": "object",
+  "required": ["schemaVersion", "presentations"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "$ref": "defs.schema.json#/$defs/schemaVersion" },
+    "presentations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "subtitle",
+          "summary",
+          "presentation_path",
+          "published",
+          "featured"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+          "year": { "type": "number" },
+          "title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+          "subtitle": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+          "summary": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+          "presentation_path": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+          "generated_path": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+          "published": { "type": "boolean" },
+          "featured": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}

--- a/slides/public/schema/site.schema.json
+++ b/slides/public/schema/site.schema.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://slide-spec.dev/schema/site.schema.json",
+  "title": "Slide Spec site.yaml",
+  "type": "object",
+  "required": ["schemaVersion", "site"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "$ref": "defs.schema.json#/$defs/schemaVersion" },
+    "site": {
+      "type": "object",
+      "required": ["title", "home_intro", "home_cta_label", "presentations_cta_label", "links"],
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": { "sitemap_enabled": { "const": true } },
+            "required": ["sitemap_enabled"]
+          },
+          "then": { "required": ["deployment_url"] }
+        }
+      ],
+      "properties": {
+        "title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "deployment_url": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "sitemap_enabled": { "type": "boolean" },
+        "metadata": { "$ref": "defs.schema.json#/$defs/metadata" },
+        "mascot": { "$ref": "#/$defs/optionalImage" },
+        "data_sources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["type", "url"],
+            "additionalProperties": false,
+            "properties": {
+              "type": { "const": "github" },
+              "url": {
+                "allOf": [
+                  { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                  {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*://(www\\.)?github\\.com(?:/|$)"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "project_badge": { "$ref": "#/$defs/projectBadge" },
+        "presentation_logo": { "$ref": "#/$defs/optionalImage" },
+        "navigation": { "$ref": "#/$defs/navigation" },
+        "app_footer": { "$ref": "#/$defs/appFooter" },
+        "attribution": { "$ref": "#/$defs/attribution" },
+        "presentation_chrome": { "$ref": "#/$defs/presentationChrome" },
+        "presentation_toolbar": { "$ref": "#/$defs/presentationToolbar" },
+        "home_hero": { "$ref": "#/$defs/homeHero" },
+        "home_intro": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "home_cta_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "presentations_cta_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "presentations_page": { "$ref": "#/$defs/presentationsPage" },
+        "links": {
+          "type": "object",
+          "required": ["repository", "docs", "community"],
+          "additionalProperties": false,
+          "properties": {
+            "repository": { "$ref": "defs.schema.json#/$defs/link" },
+            "docs": { "$ref": "defs.schema.json#/$defs/link" },
+            "community": { "$ref": "defs.schema.json#/$defs/link" }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "optionalImage": {
+      "type": "object",
+      "additionalProperties": false,
+      "dependentRequired": { "alt": ["url"] },
+      "properties": {
+        "url": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "alt": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+      }
+    },
+    "projectBadge": {
+      "type": "object",
+      "additionalProperties": false,
+      "anyOf": [
+        { "required": ["label"] },
+        { "required": ["fa_icon"] }
+      ],
+      "properties": {
+        "label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "fa_icon": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "icon_position": { "enum": ["before", "after"] }
+      }
+    },
+    "navigation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "brand_title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "home_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "presentations_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "latest_presentation_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "docs_enabled": { "type": "boolean" },
+        "toggle_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+      }
+    },
+    "appFooter": {
+      "type": "object",
+      "additionalProperties": false,
+      "dependentRequired": {
+        "repository_label": ["repository_url"],
+        "repository_url": ["repository_label"]
+      },
+      "properties": {
+        "repository_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "repository_url": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+      }
+    },
+    "attribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "dependentRequired": {
+        "label": ["url"],
+        "url": ["label"]
+      },
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "url": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+      }
+    },
+    "presentationChrome": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mark_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+      }
+    },
+    "presentationToolbar": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "navigation_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "previous_slide_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "next_slide_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "presentation_mode_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "shortcut_help_title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "shortcut_help_body": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "shortcut_help_dismiss_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+      }
+    },
+    "homeHero": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title_primary": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "title_accent": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "subtitle": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+      }
+    },
+    "presentationsPage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "search_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "search_placeholder": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "year_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "all_years_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "open_presentation_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "empty_title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "empty_message": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "previous_page_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "next_page_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "page_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "page_of_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "showing_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "total_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "presentation_singular_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "presentation_plural_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds public JSON Schema files for Slide Spec YAML documents, wires scaffolded/generated YAML to include `yaml-language-server` schema comments, and aligns runtime validation/docs with the published schemas. Also adds schema conformance tests and a headless YAML language server integration test so editor diagnostics and completions are validated in CI through the shared quality gate.

## Related issue

Related to #99

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (describe below)

## Breaking changes

- [ ] Yes (describe below)
- [x] No

## Checklist

- [x] I have tested this locally
- [x] Quality gates pass (see project READMEs for specific gates)
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes

Local validation run:

- `cd shared && npm run verify`
- `cd shared && npm audit --audit-level=moderate`
- `cd cli && npm run verify`
- `cd cli && npm run coverage`
- `cd app && npm run verify`
- `cd app && npm run validate:content`
- `cd app && npm run coverage`
- `cd docs && npm run verify`
- `cd docs && npm run a11y`
- repo markdownlint and cspell
- `git diff --check`