### PR TITLE
Standardizing messaging/positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Slide Spec
 
-**Create beautiful slides from YAML, not PowerPoint.**
+**Create beautiful slides from YAML - presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.**
 
 [![npm](https://img.shields.io/npm/v/@slide-spec/cli)](https://www.npmjs.com/package/@slide-spec/cli)
 [![CI](https://img.shields.io/github/actions/workflow/status/lreading/slide-spec/main.yml?branch=main&label=CI)](https://github.com/lreading/slide-spec/actions/workflows/main.yml)
@@ -17,12 +17,12 @@
 
 <img src="assets/readme-divider.svg" width="100%" height="8" alt="" />
 
-Slide Spec turns structured YAML into a static slide deck you can host anywhere. Keep your presentations in the same repo as your code so teams can review them in PRs and diff changes like any other project artifact.
+Slide Spec turns structured YAML into static slide decks you can host anywhere. Keep presentations in the same repo as your code so teams can review them in PRs, diff changes, and publish open formats without proprietary authoring tools.
 
-- Write slides as structured YAML you can diff, lint, and generate
+- Write slides as structured YAML you can diff, lint, and review
 - Build a static site you can deploy to GitHub Pages, S3, or any CDN
-- No proprietary file formats or authoring tools
-- Validation baked into CI for a GitOps workflow
+- Share presentations as open web output, not proprietary files
+- Use validation in CI for a source-controlled workflow
 
 <img src="assets/readme-divider.svg" width="100%" height="8" alt="" />
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,8 +1,8 @@
 # Slide Spec CLI
 
-Create beautiful slides from YAML.
+Create beautiful slides from YAML - presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.
 
-Write presentations as structured data. Version control them like code, review them in pull requests, and publish them without relying on proprietary slide formats.
+Write presentations as structured data. Version control them like code, review them in pull requests, and publish static sites without relying on proprietary slide formats.
 
 ![Slide Spec demo](../assets/readme-demo.gif)
 
@@ -10,13 +10,13 @@ Write presentations as structured data. Version control them like code, review t
 
 ## Why Slide Spec?
 
-Slide Spec is for developers, docs-as-code teams, and open source projects that want presentations to be:
+Slide Spec is for technical maintainers, docs-as-code teams, and open source projects that want presentations to be:
 
 - **Structured** instead of hand-edited in opaque binaries
 - **Version controlled** alongside code and docs
 - **Reviewable** in pull requests
-- **Reusable** across updates, releases, and community reports
-- **Openly shareable** without locking content into proprietary authoring tools
+- **Reusable** across updates, releases, briefings, and reports
+- **Openly shareable** as static web output without proprietary authoring tools
 
 <img src="../assets/readme-divider.svg" width="100%" height="8" alt="" />
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@slide-spec/cli",
   "version": "0.0.0-alpha.0",
-  "description": "CLI for Slide Spec: scaffold, validate, fetch, build, and serve YAML-driven slide decks.",
+  "description": "Create beautiful slides from YAML - presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.",
   "license": "Apache-2.0",
   "type": "module",
   "engines": {
@@ -24,7 +24,9 @@
     "presentation",
     "yaml",
     "cli",
-    "static-site"
+    "static-site",
+    "open-source",
+    "collaboration"
   ],
   "publishConfig": {
     "access": "public"

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
     },
   },
   title: 'Slide Spec',
-  description: 'Open source, YAML-driven slide decks with connectors, templates, and static builds.',
+  description: 'Create beautiful slides from YAML - presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.',
   cleanUrls: true,
   lastUpdated: false,
   head: [
@@ -18,7 +18,7 @@ export default defineConfig({
     ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
     ['meta', { name: 'theme-color', content: '#1e1e2e' }],
     ['meta', { property: 'og:title', content: 'Slide Spec documentation' }],
-    ['meta', { property: 'og:description', content: 'Open source, YAML-driven slide decks with connectors, templates, and static builds.' }],
+    ['meta', { property: 'og:description', content: 'Create beautiful slides from YAML - presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:url', content: `${siteUrl}/` }],
     ['meta', { property: 'og:image', content: `${siteUrl}/screenshots/home-reference.png` }],

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,6 @@
 # Concepts
 
-Slide Spec turns YAML files into a static presentation website. This page explains the core ideas you need to understand before writing your first deck.
+Slide Spec creates beautiful slides from YAML by treating presentations as structured data for open sharing and collaboration. This page explains the core ideas you need to understand before writing your first deck.
 
 ## Content directory
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 
 hero:
   name: Slide Spec
-  tagline: Create stunning presentations using structured data. Choose from pre-made templates, connect your data sources, and output a static site you can host anywhere. No proprietary tools or file formats.
+  tagline: Create beautiful slides from YAML - presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.
   actions:
     - theme: brand
       text: Get started
@@ -14,15 +14,15 @@ hero:
 
 features:
   - title: Presentations as data
-    details: Slides live in structured files alongside your code. Use version control, CI, or any workflow you already have. Content and generated data stay separate so automation never overwrites your work.
+    details: Slides live in structured YAML alongside your code. Use version control, CI, or any workflow you already have. Content and generated data stay separate so automation never overwrites your work.
     link: /schema/
     linkText: Schema reference
   - title: Built for flexibility
-    details: Software updates, product reviews, security reports, community recaps. Connect any data source and pick from a library of templates to match your use case.
+    details: Software updates, product reviews, security reports, community recaps. Author data by hand or use a connector, then pick from a library of templates to match your use case.
     link: /examples/
     linkText: View examples
   - title: Open source, open output
-    details: Fully open source. The build output is plain HTML, CSS, and JS. No proprietary formats, no vendor lock-in. Host it anywhere you want.
+    details: Built for open source and useful anywhere. The build output is plain HTML, CSS, and JS, so you can host it wherever static sites run.
     link: https://github.com/lreading/slide-spec
     linkText: GitHub
 ---

--- a/docs/meta/agent-assistance.md
+++ b/docs/meta/agent-assistance.md
@@ -1,6 +1,6 @@
 # Agent Assistance
 
-slide-spec's YAML-first design works well with AI coding assistants.
+Slide Spec's structured YAML design works well with AI coding assistants.
 
 **Good fits:** drafting `presentation.yaml` slides, filling `generated.yaml` from approved data, running schema validation, regenerating screenshots from fixtures.
 

--- a/docs/scripts/generate-site-files.ts
+++ b/docs/scripts/generate-site-files.ts
@@ -36,7 +36,7 @@ class DocumentationSiteFileGenerator {
     const lines = [
       '# Slide Spec Docs',
       '',
-      '> Canonical documentation for Slide Spec, a YAML-first static site and presentation system. Use these pages for the validated file formats, built-in slide templates, CLI workflow, and worked examples.',
+      '> Canonical documentation for Slide Spec: create beautiful slides from YAML - presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.',
       '',
       'Important notes:',
       '- Validation is strict. Prefer the schema reference over inference from examples.',

--- a/slides/content/site.yaml
+++ b/slides/content/site.yaml
@@ -5,10 +5,10 @@ site:
   deployment_url: https://www.slide-spec.dev
   sitemap_enabled: true
   metadata:
-    title: Slide Spec | YAML-Driven Slide Decks
-    description: Slide Spec turns structured YAML into static slide decks you can review in PRs and host anywhere.
+    title: Slide Spec | Beautiful Slides from YAML
+    description: Create beautiful slides from YAML - presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.
     image_url: /social-preview.png
-    image_alt: Slide Spec homepage preview with YAML-driven presentation examples.
+    image_alt: Slide Spec homepage preview with YAML-authored presentation examples.
   mascot:
     url: content/assets/slide-spec-mascot.svg
     alt: Slide Spec mascot
@@ -26,7 +26,7 @@ site:
     title_primary: Slide
     title_accent: Spec
     subtitle: Create beautiful slides from YAML
-  home_intro: Slide Spec turns structured YAML into static slide decks you can host anywhere. Keep presentations in the same repo as your code, review them in PRs, and skip proprietary authoring tools.
+  home_intro: Presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.
   home_cta_label: See Slide Spec in action
   presentations_cta_label: Browse the showcase
   navigation:


### PR DESCRIPTION
## What

Standardizes the messaging.  For now, I've settled on:
> Create beautiful slides from YAML - presentations as structured data for open sharing and collaboration. Built for open source, usable everywhere.

I think this strikes the balance between being describing _what_ slide-spec is, as well as the _intent_.  OSS is at the core of slide-spec.

## Related issue

<!-- Link the issue this PR addresses. An issue is required before opening a PR. -->

Closes #105 


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (describe below)

<!-- If selecting "Other", please describe the type of change -->

## Breaking changes

<!-- Does this PR introduce a breaking change? Slide Spec follows semver - breaking changes must be clearly documented. -->

- [ ] Yes (describe below)
- [x] No

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes
