### PR TITLE
[codex] Add docs links to scaffolded YAML

### DIFF
--- a/cli/examples-synced/community-update/presentations/2026-q1-community/generated.yaml
+++ b/cli/examples-synced/community-update/presentations/2026-q1-community/generated.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:

--- a/cli/examples-synced/community-update/presentations/2026-q1-community/presentation.yaml
+++ b/cli/examples-synced/community-update/presentations/2026-q1-community/presentation.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:

--- a/cli/examples-synced/community-update/presentations/index.yaml
+++ b/cli/examples-synced/community-update/presentations/index.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:

--- a/cli/examples-synced/community-update/site.yaml
+++ b/cli/examples-synced/community-update/site.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:

--- a/cli/examples-synced/open-source-update/presentations/2026-q1-update/generated.yaml
+++ b/cli/examples-synced/open-source-update/presentations/2026-q1-update/generated.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:

--- a/cli/examples-synced/open-source-update/presentations/2026-q1-update/presentation.yaml
+++ b/cli/examples-synced/open-source-update/presentations/2026-q1-update/presentation.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:

--- a/cli/examples-synced/open-source-update/presentations/index.yaml
+++ b/cli/examples-synced/open-source-update/presentations/index.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:

--- a/cli/examples-synced/open-source-update/site.yaml
+++ b/cli/examples-synced/open-source-update/site.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:

--- a/cli/examples-synced/product-review/presentations/2026-q1-review/generated.yaml
+++ b/cli/examples-synced/product-review/presentations/2026-q1-review/generated.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:

--- a/cli/examples-synced/product-review/presentations/2026-q1-review/presentation.yaml
+++ b/cli/examples-synced/product-review/presentations/2026-q1-review/presentation.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:

--- a/cli/examples-synced/product-review/presentations/index.yaml
+++ b/cli/examples-synced/product-review/presentations/index.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:

--- a/cli/examples-synced/product-review/site.yaml
+++ b/cli/examples-synced/product-review/site.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:

--- a/cli/examples-synced/security-posture/presentations/2026-q1-posture/generated.yaml
+++ b/cli/examples-synced/security-posture/presentations/2026-q1-posture/generated.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:

--- a/cli/examples-synced/security-posture/presentations/2026-q1-posture/presentation.yaml
+++ b/cli/examples-synced/security-posture/presentations/2026-q1-posture/presentation.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:

--- a/cli/examples-synced/security-posture/presentations/index.yaml
+++ b/cli/examples-synced/security-posture/presentations/index.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:

--- a/cli/examples-synced/security-posture/site.yaml
+++ b/cli/examples-synced/security-posture/site.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:

--- a/cli/src/application/TdCliApplicationService.spec.ts
+++ b/cli/src/application/TdCliApplicationService.spec.ts
@@ -441,6 +441,9 @@ describe('TdCliApplicationService', () => {
     })
 
     expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain('schemaVersion:')
+    expect(fileSystem.writes.get('/repo/content/site.yaml')?.startsWith(
+      '# Slide Spec\n# https://www.slide-spec.dev/\n# Documentation: https://docs.slide-spec.dev/\n',
+    )).toBe(true)
     expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain(
       '# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json',
     )
@@ -449,6 +452,9 @@ describe('TdCliApplicationService', () => {
     expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain('https://example.com')
     expect(fileSystem.writes.get('/repo/content/site.yaml')).toContain('data_sources:')
     expect(fileSystem.writes.get('/repo/content/presentations/2026-q1/presentation.yaml')).toContain('schemaVersion:')
+    expect(fileSystem.writes.get('/repo/content/presentations/2026-q1/presentation.yaml')?.startsWith(
+      '# Slide Spec\n# https://www.slide-spec.dev/\n# Documentation: https://docs.slide-spec.dev/\n',
+    )).toBe(true)
     expect(fileSystem.writes.get('/repo/content/presentations/2026-q1/presentation.yaml')).toContain(
       '# yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json',
     )

--- a/cli/src/application/TdCliApplicationService.ts
+++ b/cli/src/application/TdCliApplicationService.ts
@@ -142,7 +142,7 @@ export class TdCliApplicationService implements TdCliService {
         ...(input.docsUrl !== undefined ? { docsUrl: input.docsUrl } : {}),
         ...(input.websiteUrl !== undefined ? { websiteUrl: input.websiteUrl } : {}),
         ...(input.githubDataSourceUrl !== undefined ? { githubDataSourceUrl: input.githubDataSourceUrl } : {}),
-      }), { schemaUrl: slideSpecSchemaUrls.site })
+      }), { schemaUrl: slideSpecSchemaUrls.site, includeSlideSpecHeader: true })
       createdPaths.push(paths.getSiteConfigPath())
     }
     const presentationPath = paths.getPresentationPath(input.presentationId)
@@ -152,6 +152,7 @@ export class TdCliApplicationService implements TdCliService {
 
     await this.yamlWriter.writeDocument(presentationPath, presentationDocument, {
       schemaUrl: slideSpecSchemaUrls.presentation,
+      includeSlideSpecHeader: true,
     })
     await this.generatedDataStore.writeGeneratedData(paths, { id: input.presentationId }, generatedDocument)
     createdPaths.push(presentationPath, generatedPath)

--- a/cli/src/generation/GeneratedDataStore.spec.ts
+++ b/cli/src/generation/GeneratedDataStore.spec.ts
@@ -93,6 +93,9 @@ generated:
     expect(fileSystem.files.get('/workspace/project/content/presentations/2026-q1/generated.yaml')).toContain(
       '# yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json',
     )
+    expect(fileSystem.files.get('/workspace/project/content/presentations/2026-q1/generated.yaml')?.startsWith(
+      '# Slide Spec\n# https://www.slide-spec.dev/\n# Documentation: https://docs.slide-spec.dev/\n',
+    )).toBe(true)
     expect(fileSystem.files.get('/workspace/project/content/presentations/2026-q1/generated.yaml')).toContain(
       'schemaVersion:',
     )

--- a/cli/src/generation/GeneratedDataStore.ts
+++ b/cli/src/generation/GeneratedDataStore.ts
@@ -55,6 +55,7 @@ export class GeneratedDataStore {
       generated,
     }, {
       schemaUrl: slideSpecSchemaUrls.generated,
+      includeSlideSpecHeader: true,
     })
     return generatedPath
   }

--- a/cli/src/init/PresentationIndexStore.spec.ts
+++ b/cli/src/init/PresentationIndexStore.spec.ts
@@ -82,6 +82,9 @@ presentations:
     ])
 
     const content = fileSystem.files.get('/workspace/project/content/presentations/index.yaml') ?? ''
+    expect(content.startsWith(
+      '# Slide Spec\n# https://www.slide-spec.dev/\n# Documentation: https://docs.slide-spec.dev/\n',
+    )).toBe(true)
     expect(content).toContain('# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json')
     expect(content).toContain('schemaVersion:')
     expect(content.indexOf('id: 2025-q4')).toBeLessThan(content.indexOf('id: 2026-q1'))
@@ -171,6 +174,9 @@ presentations:
     ])
 
     const content = fileSystem.files.get('/workspace/project/content/presentations/index.yaml') ?? ''
+    expect(content.startsWith(
+      '# Slide Spec\n# https://www.slide-spec.dev/\n# Documentation: https://docs.slide-spec.dev/\n',
+    )).toBe(true)
     expect(content).toContain('# yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json')
     expect(content).toContain('schemaVersion:')
     expect(content).toContain('presentation_path: presentations/2026-q1/presentation.yaml')

--- a/cli/src/init/PresentationIndexStore.ts
+++ b/cli/src/init/PresentationIndexStore.ts
@@ -37,6 +37,7 @@ export class PresentationIndexStore {
       presentations: entries,
     }, {
       schemaUrl: slideSpecSchemaUrls.presentationsIndex,
+      includeSlideSpecHeader: true,
     })
   }
 }

--- a/cli/src/io/YamlWriter.spec.ts
+++ b/cli/src/io/YamlWriter.spec.ts
@@ -57,4 +57,24 @@ describe('YamlWriter', () => {
       '# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json\n',
     )).toBe(true)
   })
+
+  it('prepends the Slide Spec header before schema comments when requested', async () => {
+    const fileSystem = new MemoryFileSystem()
+    const writer = new YamlWriter(fileSystem)
+
+    await writer.writeDocument('/tmp/site.yaml', { schemaVersion: 1, site: {} }, {
+      schemaUrl: 'https://slide-spec.dev/schema/site.schema.json',
+      includeSlideSpecHeader: true,
+    })
+
+    expect(fileSystem.writes.get('/tmp/site.yaml')?.startsWith(
+      [
+        '# Slide Spec',
+        '# https://www.slide-spec.dev/',
+        '# Documentation: https://docs.slide-spec.dev/',
+        '# yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json',
+        'schemaVersion:',
+      ].join('\n'),
+    )).toBe(true)
+  })
 })

--- a/cli/src/io/YamlWriter.ts
+++ b/cli/src/io/YamlWriter.ts
@@ -6,16 +6,26 @@ import type { FileSystem } from './FileSystem'
 
 interface WriteYamlDocumentOptions {
   schemaUrl?: string
+  includeSlideSpecHeader?: boolean
 }
 
 export class YamlWriter {
+  public static readonly slideSpecHeader = [
+    '# Slide Spec',
+    '# https://www.slide-spec.dev/',
+    '# Documentation: https://docs.slide-spec.dev/',
+  ].join('\n')
+
   public constructor(private readonly fileSystem: FileSystem = new NodeFileSystem()) {}
 
   public async writeDocument(path: string, document: unknown, options: WriteYamlDocumentOptions = {}): Promise<void> {
+    const slideSpecHeader = options.includeSlideSpecHeader
+      ? `${YamlWriter.slideSpecHeader}\n`
+      : ''
     const schemaComment = options.schemaUrl
       ? `# yaml-language-server: $schema=${options.schemaUrl}\n`
       : ''
 
-    await this.fileSystem.writeTextFile(path, `${schemaComment}${stringify(document)}`)
+    await this.fileSystem.writeTextFile(path, `${slideSpecHeader}${schemaComment}${stringify(document)}`)
   }
 }

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -50,4 +50,4 @@ content/
 
 If `site.yaml` or `index.yaml` already exist, they are updated rather than overwritten (unless `--force` is used).
 
-Scaffolded YAML files include `yaml-language-server` comments that point to the public Slide Spec JSON Schemas for editor validation and autocomplete.
+Scaffolded YAML files start with Slide Spec homepage and documentation links, then include `yaml-language-server` comments that point to the public Slide Spec JSON Schemas for editor validation and autocomplete.

--- a/examples/community-update/content/presentations/2026-q1-community/generated.yaml
+++ b/examples/community-update/content/presentations/2026-q1-community/generated.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:

--- a/examples/community-update/content/presentations/2026-q1-community/presentation.yaml
+++ b/examples/community-update/content/presentations/2026-q1-community/presentation.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:

--- a/examples/community-update/content/presentations/index.yaml
+++ b/examples/community-update/content/presentations/index.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:

--- a/examples/community-update/content/site.yaml
+++ b/examples/community-update/content/site.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:

--- a/examples/open-source-update/content/presentations/2026-q1-update/generated.yaml
+++ b/examples/open-source-update/content/presentations/2026-q1-update/generated.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:

--- a/examples/open-source-update/content/presentations/2026-q1-update/presentation.yaml
+++ b/examples/open-source-update/content/presentations/2026-q1-update/presentation.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:

--- a/examples/open-source-update/content/presentations/index.yaml
+++ b/examples/open-source-update/content/presentations/index.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:

--- a/examples/open-source-update/content/site.yaml
+++ b/examples/open-source-update/content/site.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:

--- a/examples/product-review/content/presentations/2026-q1-review/generated.yaml
+++ b/examples/product-review/content/presentations/2026-q1-review/generated.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:

--- a/examples/product-review/content/presentations/2026-q1-review/presentation.yaml
+++ b/examples/product-review/content/presentations/2026-q1-review/presentation.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:

--- a/examples/product-review/content/presentations/index.yaml
+++ b/examples/product-review/content/presentations/index.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:

--- a/examples/product-review/content/site.yaml
+++ b/examples/product-review/content/site.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:

--- a/examples/security-posture/content/presentations/2026-q1-posture/generated.yaml
+++ b/examples/security-posture/content/presentations/2026-q1-posture/generated.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/generated.schema.json
 schemaVersion: 1
 generated:

--- a/examples/security-posture/content/presentations/2026-q1-posture/presentation.yaml
+++ b/examples/security-posture/content/presentations/2026-q1-posture/presentation.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentation.schema.json
 schemaVersion: 1
 presentation:

--- a/examples/security-posture/content/presentations/index.yaml
+++ b/examples/security-posture/content/presentations/index.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/presentations-index.schema.json
 schemaVersion: 1
 presentations:

--- a/examples/security-posture/content/site.yaml
+++ b/examples/security-posture/content/site.yaml
@@ -1,3 +1,6 @@
+# Slide Spec
+# https://www.slide-spec.dev/
+# Documentation: https://docs.slide-spec.dev/
 # yaml-language-server: $schema=https://slide-spec.dev/schema/site.schema.json
 schemaVersion: 1
 site:


### PR DESCRIPTION
## What

Adds the Slide Spec homepage and documentation header to YAML files created by CLI scaffolding, including blank `init` scaffolds and bundled example scaffolds used by `init --from-example`.

## Related issue

Closes #81


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (describe below)

<!-- If selecting "Other", please describe the type of change -->

## Breaking changes

- [ ] Yes (describe below)
- [x] No

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes