### PR TITLE
fix(docs): add top margin on mobile home page

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -55,3 +55,9 @@
 .dark .vp-doc .template-doc-shot img {
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
 }
+
+@media (max-width: 767px) {
+  .VPHomeHero {
+    padding-top: calc(4rem + 100px) !important;
+  }
+}


### PR DESCRIPTION
## What

Add top padding to the mobile home page hero section so it doesn't overlap the fixed navbar. On screens below 768px the `.VPHomeHero` element now has a `padding-top: calc(4rem + 100px)` override scoped via media query. The `!important` flag is required because VitePress sets padding as an inline style on this element, and inline styles can only be overridden by `!important`.

## Related issue

Closes #79

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Breaking changes

- [ ] Yes (describe below)
- [x] No

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [ ] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes