### PR TITLE
Add e2e test coverage

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -52,6 +52,8 @@ jobs:
             command: pnpm --filter @slide-spec/cli build
           - name: CLI Unit Tests
             command: pnpm --filter @slide-spec/cli coverage
+          - name: CLI E2E
+            command: pnpm --filter @slide-spec/cli e2e
           - name: Docs A11y
             command: pnpm --filter @slide-spec/docs a11y
             playwright: docs
@@ -71,6 +73,22 @@ jobs:
       - run: ${{ matrix.command }}
         env:
           CI: ${{ matrix.ci }}
+
+  cli-connector-e2e:
+    name: CLI Connector E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+      - run: corepack enable
+      - run: corepack prepare pnpm@11.2.2 --activate
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @slide-spec/cli e2e:connectors
+        env:
+          CI: true
+          GH_TOKEN: ${{ github.token }}
 
   markdown:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ The core audience is comfortable with source control, static sites, and YAML dat
 - Unit tests must isolate one unit of work and mock external dependencies.
 - Do not test third-party code in unit tests.
 - Add or update e2e tests for user-facing behavior that needs end-to-end confidence.
+- CLI e2e coverage must exercise the built CLI artifact, not the npm-published package or TypeScript source entrypoint. Cover every command function, option, default, and expected error path; when adding or changing CLI behavior, update the matrix instead of relying only on unit tests.
 - Add or update visual regression tests for new pages, templates, or materially changed visual features.
 - Never update visual baselines without explicit human permission. Stop and ask first.
 - For regressions, prefer adding a failing test first, then fix to green.

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,7 +34,7 @@ From there, edit your content, validate it, fetch generated GitHub-backed conten
 
 ```sh
 npx @slide-spec/cli validate
-# Requires GITHUB_PAT in your environment or in a .env file at the project root
+# Requires GITHUB_PAT, GITHUB_TOKEN, or GH_TOKEN in your environment or in a .env file at the project root
 npx @slide-spec/cli fetch
 npx @slide-spec/cli build
 ```
@@ -94,7 +94,7 @@ slide-spec <command> --help
 
 `fetch` can enrich generated content with GitHub data.
 
-To enable authenticated GitHub-backed fetches, copy `.env.example` to `.env` in your project root and set:
+To enable authenticated GitHub-backed fetches, set a token in your shell environment or copy `.env.example` to `.env` in your project root and set:
 
 ```env
 GITHUB_PAT=your_token_here
@@ -103,6 +103,7 @@ GITHUB_PAT=your_token_here
 Notes:
 
 - A token is optional
+- `GITHUB_PAT`, `GITHUB_TOKEN`, and `GH_TOKEN` are supported; shell environment values take precedence over `.env`
 - `fetch` supports best-effort mode without a token
 - `init` can write a masked `GITHUB_PAT` entry into `.env` during setup
 - `fetch` also supports date ranges

--- a/cli/e2e/cli-e2e-helpers.ts
+++ b/cli/e2e/cli-e2e-helpers.ts
@@ -1,0 +1,196 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { parse } from 'yaml'
+
+const helperDirectory = dirname(fileURLToPath(import.meta.url))
+
+export const cliRoot = resolve(helperDirectory, '..')
+export const repoRoot = resolve(cliRoot, '..')
+export const cliBin = resolve(cliRoot, 'dist', 'index.js')
+
+export interface CliResult {
+  readonly status: number | null
+  readonly stdout: string
+  readonly stderr: string
+}
+
+interface RunCliOptions {
+  readonly cwd?: string
+  readonly env?: Record<string, string | undefined>
+  readonly input?: string
+  readonly inputLines?: readonly string[]
+  readonly timeoutMs?: number
+}
+
+interface StartedCli {
+  readonly child: ChildProcessWithoutNullStreams
+  stdout(): string
+  stderr(): string
+  stop(): Promise<void>
+}
+
+export async function createTempDirectory(name: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), `slide-spec-${name}-`))
+}
+
+export async function runCli(args: readonly string[], options: RunCliOptions = {}): Promise<CliResult> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [cliBin, ...args], {
+      cwd: options.cwd ?? cliRoot,
+      env: {
+        ...process.env,
+        ...options.env,
+      },
+      stdio: 'pipe',
+    })
+    let stdout = ''
+    let stderr = ''
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`CLI timed out: ${args.join(' ')}`))
+    }, options.timeoutMs ?? 30000)
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8')
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8')
+    })
+    child.on('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.on('close', (status) => {
+      clearTimeout(timeout)
+      resolvePromise({ status, stdout, stderr })
+    })
+    if (options.inputLines) {
+      let lineIndex = 0
+      let inputPending = false
+      const writeNextLine = (): void => {
+        if (inputPending) {
+          return
+        }
+
+        const line = options.inputLines?.[lineIndex]
+
+        if (line === undefined) {
+          child.stdin.end()
+          return
+        }
+
+        inputPending = true
+        setTimeout(() => {
+          child.stdin.write(`${line}\n`)
+          lineIndex += 1
+          inputPending = false
+        }, 10)
+      }
+
+      child.stdout.on('data', writeNextLine)
+      child.stderr.on('data', writeNextLine)
+    } else {
+      child.stdin.end(options.input ?? '')
+    }
+  })
+}
+
+export async function startCliUntil(
+  args: readonly string[],
+  pattern: RegExp,
+  options: RunCliOptions = {},
+): Promise<StartedCli> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [cliBin, ...args], {
+      cwd: options.cwd ?? cliRoot,
+      env: {
+        ...process.env,
+        ...options.env,
+      },
+      stdio: 'pipe',
+    })
+    let stdout = ''
+    let stderr = ''
+    let settled = false
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`CLI did not reach expected output: ${args.join(' ')}`))
+    }, options.timeoutMs ?? 45000)
+    const finish = (): void => {
+      if (!settled && pattern.test(stdout + stderr)) {
+        settled = true
+        clearTimeout(timeout)
+        resolvePromise({
+          child,
+          stdout: () => stdout,
+          stderr: () => stderr,
+          stop: () => stopProcess(child),
+        })
+      }
+    }
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8')
+      finish()
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8')
+      finish()
+    })
+    child.on('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.on('close', (status) => {
+      clearTimeout(timeout)
+      if (!settled) {
+        reject(new Error(`CLI exited with ${status}: ${stdout}${stderr}`))
+      }
+    })
+    child.stdin.end(options.input ?? '')
+  })
+}
+
+export async function readYamlFile<T>(path: string): Promise<T> {
+  return parse(await readFile(path, 'utf8')) as T
+}
+
+export async function readText(path: string): Promise<string> {
+  return readFile(path, 'utf8')
+}
+
+export async function removePath(path: string): Promise<void> {
+  await rm(path, { recursive: true, force: true })
+}
+
+export function projectPath(projectRoot: string, ...segments: string[]): string {
+  return resolve(projectRoot, ...segments)
+}
+
+export async function createFakeBrowserCommand(): Promise<Record<string, string>> {
+  const binRoot = await createTempDirectory('fake-browser-bin')
+  const command = process.platform === 'darwin' ? 'open' : 'xdg-open'
+  const commandPath = join(binRoot, command)
+
+  await mkdir(binRoot, { recursive: true })
+  await writeFile(commandPath, '#!/usr/bin/env sh\nexit 0\n', { mode: 0o755 })
+
+  return {
+    PATH: `${binRoot}${delimiter}${process.env.PATH ?? ''}`,
+  }
+}
+
+async function stopProcess(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null) {
+    return
+  }
+
+  await new Promise<void>((resolvePromise) => {
+    child.once('close', () => resolvePromise())
+    child.kill('SIGTERM')
+  })
+}

--- a/cli/e2e/cli.commands.e2e.spec.ts
+++ b/cli/e2e/cli.commands.e2e.spec.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdir, writeFile } from 'node:fs/promises'
+
+import {
+  createTempDirectory,
+  projectPath,
+  readText,
+  removePath,
+  runCli,
+} from './cli-e2e-helpers'
+
+const cleanupPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => removePath(path)))
+})
+
+async function createProjectRoot(name: string): Promise<string> {
+  const projectRoot = await createTempDirectory(name)
+  cleanupPaths.push(projectRoot)
+  return projectRoot
+}
+
+async function initBlankProject(projectRoot: string): Promise<void> {
+  const result = await runCli([
+    'init',
+    projectRoot,
+    '--presentation-id',
+    '2026-q1',
+    '--title',
+    'Quarterly Update',
+    '--subtitle',
+    'Spring 2026',
+    '--from-date',
+    '2026-03-01',
+    '--to-date',
+    '2026-05-31',
+    '--summary',
+    'A focused project update.',
+    '--github-data-source-url',
+    'https://github.com/lreading/slide-spec',
+    '--force',
+  ])
+
+  expect(result.status).toBe(0)
+}
+describe('built CLI command e2e', () => {
+  it('prints global, command-specific, and unknown-topic help matrix', async () => {
+    const checks: Array<readonly [readonly string[], string]> = [
+      [['--help'], 'Usage: slide-spec <command> [options]'],
+      [['-h'], 'Usage: slide-spec <command> [options]'],
+      [['help'], 'Commands:'],
+      [['help', 'init'], 'Usage: slide-spec init'],
+      [['help', 'fetch'], 'Usage: slide-spec fetch'],
+      [['help', 'validate'], 'Usage: slide-spec validate'],
+      [['help', 'serve'], 'Usage: slide-spec serve'],
+      [['help', 'build'], 'Usage: slide-spec build'],
+      [['init', '-h'], 'Usage: slide-spec init'],
+      [['fetch', '-h'], 'Usage: slide-spec fetch'],
+      [['validate', '-h'], 'Usage: slide-spec validate'],
+      [['serve', '-h'], 'Usage: slide-spec serve'],
+      [['build', '-h'], 'Usage: slide-spec build'],
+    ]
+    for (const [args, expected] of checks) {
+      const result = await runCli(args)
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain(expected)
+    }
+    const unknownTopic = await runCli(['help', 'wat'])
+    expect(unknownTopic.status).toBe(0)
+    expect(unknownTopic.stdout).toContain('Unknown help topic "wat".')
+  })
+
+  it('validates global log-path parsing and sanitizes log output', async () => {
+    const projectRoot = await createProjectRoot('log-path')
+    const logPath = projectPath(projectRoot, 'cli.log')
+    const logPathWithEquals = projectPath(projectRoot, 'with-equals.log')
+    const helpResult = await runCli(['--log-path', logPath, 'help', 'validate'])
+    const equalsResult = await runCli([`--log-path=${logPathWithEquals}`, 'help', 'build'])
+    const missingPath = await runCli(['--log-path'])
+    const emptyPath = await runCli(['--log-path='])
+    const unwritablePath = await runCli(['--log-path', '/proc/1/mem', 'help'])
+    const duplicatePath = await runCli(['--log-path', logPath, '--log-path=another.log', 'help'])
+    const sanitized = await runCli(['--log-path', logPath, 'GH_TOKEN=secret-token'])
+
+    expect(helpResult.status).toBe(0)
+    expect(equalsResult.status).toBe(0)
+    expect(await readText(logPath)).toContain('Usage: slide-spec validate')
+    expect(await readText(logPathWithEquals)).toContain('Usage: slide-spec build')
+    expect(missingPath.status).toBe(1)
+    expect(missingPath.stderr).toContain('Option "--log-path" must include a file path.')
+    expect(emptyPath.status).toBe(1)
+    expect(emptyPath.stderr).toContain('Option "--log-path" must include a file path.')
+    expect(unwritablePath.status).toBe(1)
+    expect(unwritablePath.stderr).toMatch(/EACCES|permission/i)
+    expect(duplicatePath.status).toBe(1)
+    expect(duplicatePath.stderr).toContain('Specify "--log-path" only once.')
+    expect(sanitized.status).toBe(1)
+    expect(sanitized.stderr).toContain('Unknown command "GH_TOKEN=[REDACTED]".')
+  })
+  it('rejects unknown commands, root conflicts, and unexpected positionals', async () => {
+    const projectRoot = await createProjectRoot('root-conflict')
+    const unknown = await runCli(['totally-unknown'])
+    const conflict = await runCli(['validate', projectRoot, '--project-root', projectRoot])
+    const unexpected = await runCli(['build', projectRoot, 'extra'])
+    expect(unknown.status).toBe(1)
+    expect(unknown.stderr).toContain('Unknown command "totally-unknown".')
+    expect(conflict.status).toBe(1)
+    expect(conflict.stderr).toContain('Specify the project root either positionally or with --project-root, not both.')
+    expect(unexpected.status).toBe(1)
+    expect(unexpected.stderr).toContain('Unexpected argument "extra".')
+  })
+  it('validates strict flag/value behavior, cwd default, and spaces in project roots', async () => {
+    const projectRoot = await createProjectRoot('validate')
+    const parent = await createProjectRoot('validate-space-parent')
+    const spaceRoot = projectPath(parent, 'project with spaces')
+    await mkdir(spaceRoot)
+    await initBlankProject(projectRoot)
+    await initBlankProject(spaceRoot)
+
+    const accidentalBooleanValue = await runCli(['validate', projectRoot, '--strict', 'unexpected'])
+    const cwdDefault = await runCli(['validate'], { cwd: projectRoot })
+    const withSpacePath = await runCli(['validate', spaceRoot])
+    expect(accidentalBooleanValue.status).toBe(0)
+    expect(accidentalBooleanValue.stdout).toContain('Content is valid')
+    expect(cwdDefault.status).toBe(0)
+    expect(cwdDefault.stdout).toContain('Content is valid')
+    expect(withSpacePath.status).toBe(0)
+    expect(withSpacePath.stdout).toContain('Content is valid')
+  })
+  it('reports validate schema/content failures for generated and presentation files', async () => {
+    const generatedInvalidRoot = await createProjectRoot('generated-invalid')
+    await initBlankProject(generatedInvalidRoot)
+    await writeFile(projectPath(generatedInvalidRoot, 'content/presentations/2026-q1/generated.yaml'), 'schemaVersion: 2\n')
+    const generatedInvalid = await runCli(['validate', generatedInvalidRoot])
+    const presentationInvalidRoot = await createProjectRoot('presentation-invalid')
+    await initBlankProject(presentationInvalidRoot)
+    await writeFile(projectPath(presentationInvalidRoot, 'content/presentations/2026-q1/presentation.yaml'), 'schemaVersion: 2\n')
+    const presentationInvalid = await runCli(['validate', presentationInvalidRoot])
+    expect(generatedInvalid.status).toBe(1)
+    expect(generatedInvalid.stderr).toContain('schemaVersion')
+    expect(presentationInvalid.status).toBe(1)
+    expect(presentationInvalid.stderr).toContain('schemaVersion')
+  })
+  it('rejects invalid serve and fetch option combinations and fetch default/root errors', async () => {
+    const projectRoot = await createProjectRoot('errors')
+    const noSourceProjectRoot = await createProjectRoot('fetch-no-source')
+    await initBlankProject(projectRoot)
+
+    const invalidPort = await runCli(['serve', projectRoot, '--port', 'not-a-port'])
+    const missingFetchId = await runCli(['fetch', projectRoot, '--from-date', '2026-01-01'])
+    const missingFromDate = await runCli(['fetch', projectRoot, '--presentation-id', '2026-q1'])
+    const fetchRootConflict = await runCli(['fetch', projectRoot, '--project-root', projectRoot, '--presentation-id', '2026-q1', '--from-date', '2026-01-01'])
+    const initWithoutDataSource = await runCli([
+      'init',
+      noSourceProjectRoot,
+      '--presentation-id',
+      '2026-q1',
+      '--title',
+      'No Source',
+      '--from-date',
+      '2026-01-01',
+    ])
+    const missingDataSource = await runCli([
+      'fetch',
+      noSourceProjectRoot,
+      '--presentation-id',
+      '2026-q1',
+      '--from-date',
+      '2026-01-01',
+      '--force',
+    ])
+    const missingDataSourceFromCwd = await runCli([
+      'fetch',
+      '--presentation-id',
+      '2026-q1',
+      '--from-date',
+      '2026-01-01',
+      '--force',
+    ], { cwd: noSourceProjectRoot })
+    expect(invalidPort.status).toBe(1)
+    expect(invalidPort.stderr).toContain('Option "--port" must be a number.')
+    expect(missingFetchId.status).toBe(1)
+    expect(missingFetchId.stderr).toContain('Missing required option: --presentation-id.')
+    expect(missingFromDate.status).toBe(1)
+    expect(missingFromDate.stderr).toContain('Missing required option: --from-date.')
+    expect(fetchRootConflict.status).toBe(1)
+    expect(fetchRootConflict.stderr).toContain('Specify the project root either positionally or with --project-root, not both.')
+    expect(initWithoutDataSource.status).toBe(0)
+    expect(missingDataSource.status).toBe(1)
+    expect(missingDataSource.stderr).toContain('site.data_sources must include exactly one github source.')
+    expect(missingDataSourceFromCwd.status).toBe(1)
+    expect(missingDataSourceFromCwd.stderr).toContain('site.data_sources must include exactly one github source.')
+  })
+})

--- a/cli/e2e/cli.connectors.e2e.spec.ts
+++ b/cli/e2e/cli.connectors.e2e.spec.ts
@@ -1,0 +1,179 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import { writeFile } from 'node:fs/promises'
+
+import {
+  cliRoot,
+  createTempDirectory,
+  projectPath,
+  readText,
+  readYamlFile,
+  removePath,
+  runCli,
+} from './cli-e2e-helpers'
+
+interface GeneratedDocument {
+  readonly generated: {
+    readonly id: string
+    readonly period: { readonly start: string; readonly end: string }
+    readonly stats: {
+      readonly issues_closed: { current: number; previous: number; delta: number }
+      readonly new_contributors: { current: number; previous: number; delta: number }
+      readonly prs_merged: { current: number; previous: number; delta: number }
+      readonly stars: { current: number; previous: number; delta: number; metadata?: { comparison_status?: string } }
+    }
+    readonly releases: unknown[]
+    readonly contributors: {
+      readonly total: number
+      readonly authors: unknown[]
+    }
+    readonly merged_prs: unknown[]
+  }
+}
+
+const cleanupPaths: string[] = []
+
+afterAll(async () => {
+  await Promise.all(cleanupPaths.map((path) => removePath(path)))
+})
+
+async function resolveTokenFromCliEnv(): Promise<string | undefined> {
+  for (const key of ['GH_TOKEN', 'GITHUB_TOKEN', 'GITHUB_PAT'] as const) {
+    if (process.env[key]) {
+      return process.env[key]
+    }
+  }
+  const envText = await readText(projectPath(cliRoot, '.env'))
+  for (const key of ['GH_TOKEN', 'GITHUB_TOKEN', 'GITHUB_PAT'] as const) {
+    const match = envText.match(new RegExp(`^\\s*${key}\\s*=\\s*(.*)\\s*$`, 'm'))
+    if (match?.[1]) {
+      return match[1].replace(/^['"]|['"]$/g, '').trim() || undefined
+    }
+  }
+  return undefined
+}
+
+async function createLiveProject(): Promise<{ projectRoot: string; presentationId: string }> {
+  const projectRoot = await createTempDirectory('connectors')
+  const presentationId = 'live-github'
+  const repository = process.env.GITHUB_REPOSITORY ?? 'lreading/slide-spec'
+  cleanupPaths.push(projectRoot)
+
+  const initResult = await runCli([
+    'init',
+    projectRoot,
+    '--presentation-id',
+    presentationId,
+    '--title',
+    'Live GitHub Connector',
+    '--from-date',
+    '2026-01-01',
+    '--to-date',
+    '2026-05-24',
+    '--github-data-source-url',
+    `https://github.com/${repository}`,
+  ])
+
+  expect(initResult.status).toBe(0)
+
+  return {
+    projectRoot,
+    presentationId,
+  }
+}
+
+describe('built CLI generated.yaml connector e2e', () => {
+  it('dry-run does not write generated.yaml and timings only print when requested', async () => {
+    const token = await resolveTokenFromCliEnv()
+    if (!token) throw new Error('Connector e2e requires GH_TOKEN, GITHUB_TOKEN, or GITHUB_PAT.')
+    const { projectRoot, presentationId } = await createLiveProject()
+    const generatedPath = projectPath(projectRoot, 'content', 'presentations', presentationId, 'generated.yaml')
+    await removePath(generatedPath)
+
+    const dryRunResult = await runCli([
+      'fetch', projectRoot, '--presentation-id', presentationId, '--from-date', '2026-01-01', '--to-date', '2026-05-24', '--dry-run', '--force',
+    ], { env: { GH_TOKEN: token }, timeoutMs: 180000 })
+    expect(dryRunResult.status).toBe(0)
+    expect(dryRunResult.stdout).toContain(`Fetched ${presentationId}`)
+    expect(dryRunResult.stdout).not.toContain('Fetch timings:')
+    await expect(readText(generatedPath)).rejects.toThrow()
+
+    const withTimingsResult = await runCli([
+      'fetch', '--project-root', projectRoot, '--presentation-id', presentationId, '--from-date', '2026-01-01', '--to-date', '2026-05-24', '--timings', '--force',
+    ], { env: { GH_TOKEN: token }, timeoutMs: 180000 })
+    expect(withTimingsResult.status).toBe(0)
+    expect(withTimingsResult.stdout).toContain('Fetch timings:')
+  })
+
+  it('fails without --force when generated.yaml exists and succeeds with --force then validate', async () => {
+    const token = await resolveTokenFromCliEnv()
+    if (!token) throw new Error('Connector e2e requires GH_TOKEN, GITHUB_TOKEN, or GITHUB_PAT.')
+    const { projectRoot, presentationId } = await createLiveProject()
+    const generatedPath = projectPath(projectRoot, 'content', 'presentations', presentationId, 'generated.yaml')
+    const withoutForceResult = await runCli([
+      'fetch', projectRoot, '--presentation-id', presentationId, '--from-date', '2026-01-01', '--to-date', '2026-05-24',
+    ], { env: { GH_TOKEN: token }, timeoutMs: 180000 })
+    expect(withoutForceResult.status).toBe(1)
+    expect(withoutForceResult.stderr).toContain('generated.yaml already exists')
+    expect(withoutForceResult.stderr).toContain('Use --force')
+
+    const withForceResult = await runCli([
+      'fetch', projectRoot, '--presentation-id', presentationId, '--from-date', '2026-01-01', '--to-date', '2026-05-24', '--force',
+    ], { env: { GH_TOKEN: token }, timeoutMs: 180000 })
+    expect(withForceResult.status).toBe(0)
+    const validateResult = await runCli(['validate', projectRoot], { timeoutMs: 120000 })
+    expect(validateResult.status).toBe(0)
+    expect(validateResult.stdout).toContain('Content is valid')
+    expect((await readText(generatedPath)).length).toBeGreaterThan(0)
+  })
+
+  it('prefers explicit shell token over invalid project .env token', async () => {
+    const token = await resolveTokenFromCliEnv()
+    if (!token) throw new Error('Connector e2e requires GH_TOKEN, GITHUB_TOKEN, or GITHUB_PAT.')
+    const { projectRoot, presentationId } = await createLiveProject()
+    await writeFile(projectPath(projectRoot, '.env'), 'GITHUB_PAT=invalid-token\n', 'utf8')
+    const result = await runCli([
+      'fetch', projectRoot, '--presentation-id', presentationId, '--from-date', '2026-01-01', '--to-date', '2026-05-24', '--dry-run', '--force',
+    ], { env: { GH_TOKEN: token, GITHUB_PAT: undefined, GITHUB_TOKEN: undefined }, timeoutMs: 180000 })
+    expect(result.status).toBe(0)
+  })
+
+  it('accepts GITHUB_TOKEN and GITHUB_PAT env names and writes valid generated.yaml shape', async () => {
+    const token = await resolveTokenFromCliEnv()
+    if (!token) throw new Error('Connector e2e requires GH_TOKEN, GITHUB_TOKEN, or GITHUB_PAT.')
+    const { projectRoot, presentationId } = await createLiveProject()
+    const generatedPath = projectPath(projectRoot, 'content', 'presentations', presentationId, 'generated.yaml')
+    for (const [name, otherA, otherB] of [
+      ['GITHUB_TOKEN', 'GITHUB_PAT', 'GH_TOKEN'],
+      ['GITHUB_PAT', 'GITHUB_TOKEN', 'GH_TOKEN'],
+    ] as const) {
+      const authResult = await runCli([
+        'fetch', projectRoot, '--presentation-id', presentationId, '--from-date', '2026-01-01', '--to-date', '2026-05-24', '--dry-run', '--force',
+      ], { env: { [name]: token, [otherA]: undefined, [otherB]: undefined }, timeoutMs: 180000 })
+      expect(authResult.status).toBe(0)
+    }
+    const result = await runCli([
+      'fetch', '--project-root', projectRoot, '--presentation-id', presentationId, '--from-date', '2026-01-01', '--to-date', '2026-05-24', '--no-previous-period', '--timings', '--force',
+    ], { env: { GH_TOKEN: token }, timeoutMs: 180000 })
+    const generated = await readYamlFile<GeneratedDocument>(generatedPath)
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Previous period comparison disabled; previous values defaulted to 0.')
+    expect(result.stdout).toContain('Fetch timings:')
+    expect(Object.keys(generated.generated.stats).sort()).toEqual([
+      'issues_closed',
+      'new_contributors',
+      'prs_merged',
+      'stars',
+    ])
+    expect(generated.generated.id).toBe(presentationId)
+    expect(generated.generated.period).toEqual({ start: '2026-01-01', end: '2026-05-24' })
+    expect(generated.generated.stats.stars.current).toBeGreaterThanOrEqual(0)
+    expect(generated.generated.stats.stars.metadata?.comparison_status).toBe('skipped')
+    expect(Array.isArray(generated.generated.releases)).toBe(true)
+    expect(generated.generated.contributors.total).toBeGreaterThanOrEqual(0)
+    expect(Array.isArray(generated.generated.contributors.authors)).toBe(true)
+    expect(Array.isArray(generated.generated.merged_prs)).toBe(true)
+    const validateResult = await runCli(['validate', projectRoot], { timeoutMs: 120000 })
+    expect(validateResult.status).toBe(0)
+  })
+})

--- a/cli/e2e/cli.examples.e2e.spec.ts
+++ b/cli/e2e/cli.examples.e2e.spec.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createTempDirectory, projectPath, readText, removePath, runCli } from './cli-e2e-helpers'
+
+const cleanupPaths: string[] = []
+const examples = ['open-source-update', 'product-review', 'security-posture', 'community-update'] as const
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => removePath(path)))
+})
+
+async function createProjectRoot(name: string): Promise<string> {
+  const projectRoot = await createTempDirectory(name)
+  cleanupPaths.push(projectRoot)
+  return projectRoot
+}
+
+describe('built CLI bundled example e2e', () => {
+  it.each(examples)('initializes, validates, and builds %s', async (exampleId) => {
+    const projectRoot = await createProjectRoot(`example-${exampleId}`)
+    const init = await runCli(['init', projectRoot, '--from-example', exampleId])
+    const validate = await runCli(['validate', projectRoot])
+    const build = await runCli(['build', projectRoot], { timeoutMs: 90000 })
+
+    expect(init.status).toBe(0)
+    expect(init.stdout).toContain(`Initialized from example "${exampleId}".`)
+    expect(validate.status).toBe(0)
+    expect(validate.stdout).toContain('Content is valid')
+    expect(build.status).toBe(0)
+    await expect(readText(projectPath(projectRoot, 'dist', 'index.html'))).resolves.toContain('<div id="app"></div>')
+  })
+})

--- a/cli/e2e/cli.init-existing.e2e.spec.ts
+++ b/cli/e2e/cli.init-existing.e2e.spec.ts
@@ -1,0 +1,169 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createTempDirectory, projectPath, readText, readYamlFile, removePath, runCli } from './cli-e2e-helpers'
+
+interface PresentationIndexDocument {
+  readonly presentations: Array<{
+    readonly id: string
+    readonly featured: boolean
+  }>
+}
+
+interface PresentationDocument {
+  readonly presentation: {
+    readonly title?: string
+    readonly subtitle?: string
+  }
+}
+
+interface GeneratedDocument {
+  readonly generated: {
+    readonly period: {
+      readonly start: string
+      readonly end: string
+    }
+  }
+}
+
+const cleanupPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => removePath(path)))
+})
+
+async function createProjectRoot(name: string): Promise<string> {
+  const projectRoot = await createTempDirectory(name)
+  cleanupPaths.push(projectRoot)
+  return projectRoot
+}
+
+async function initBlank(projectRoot: string, args: readonly string[]): Promise<void> {
+  const result = await runCli(['init', projectRoot, ...args])
+  expect(result.status).toBe(0)
+}
+
+describe('built CLI init existing-content e2e', () => {
+  it('fails for existing presentation without force and succeeds with force overwrite', async () => {
+    const projectRoot = await createProjectRoot('init-existing-force')
+    await initBlank(projectRoot, [
+      '--presentation-id', '2026-q1', '--title', 'Original', '--subtitle', 'Orig Sub', '--summary', 'Orig Sum', '--from-date', '2026-01-01',
+    ])
+
+    const fail = await runCli([
+      'init', projectRoot, '--presentation-id', '2026-q1', '--title', 'Updated', '--subtitle', 'New Sub', '--summary', 'New Sum', '--from-date', '2026-02-01', '--to-date', '2026-03-31',
+    ])
+    const pass = await runCli([
+      'init', projectRoot, '--presentation-id', '2026-q1', '--title', 'Updated', '--subtitle', 'New Sub', '--summary', 'New Sum', '--from-date', '2026-02-01', '--to-date', '2026-03-31', '--force',
+    ])
+    const presentation = await readYamlFile<PresentationDocument>(
+      projectPath(projectRoot, 'content', 'presentations', '2026-q1', 'presentation.yaml'),
+    )
+    const generated = await readYamlFile<GeneratedDocument>(
+      projectPath(projectRoot, 'content', 'presentations', '2026-q1', 'generated.yaml'),
+    )
+
+    expect(fail.status).toBe(1)
+    expect(fail.stderr).toContain('Presentation "2026-q1" already exists. Use force to overwrite scaffold files.')
+    expect(pass.status).toBe(0)
+    expect(presentation.presentation).toMatchObject({ title: 'Updated', subtitle: 'New Sub' })
+    expect(generated.generated.period).toEqual({ start: '2026-02-01', end: '2026-03-31' })
+  })
+
+  it('preserves first featured presentation when adding a second presentation', async () => {
+    const projectRoot = await createProjectRoot('init-second-presentation')
+    await initBlank(projectRoot, ['--presentation-id', '2026-first', '--title', 'First', '--from-date', '2026-01-01'])
+    await initBlank(projectRoot, ['--presentation-id', '2026-second', '--title', 'Second', '--from-date', '2026-02-01'])
+    const index = await readYamlFile<PresentationIndexDocument>(
+      projectPath(projectRoot, 'content', 'presentations', 'index.yaml'),
+    )
+    const byId = new Map(index.presentations.map((entry) => [entry.id, entry]))
+
+    expect(index.presentations).toHaveLength(2)
+    expect(byId.get('2026-first')).toMatchObject({ featured: true })
+    expect(byId.get('2026-second')).toMatchObject({ featured: false })
+  })
+
+  it('does not overwrite existing content/site.yaml on later blank init without link/data-source flags', async () => {
+    const projectRoot = await createProjectRoot('init-preserve-site')
+    await initBlank(projectRoot, ['--presentation-id', '2026-first', '--title', 'First', '--from-date', '2026-01-01'])
+    const sitePath = projectPath(projectRoot, 'content', 'site.yaml')
+    const custom = (await readText(sitePath)).replace('https://example.com/repository', 'https://example.com/custom-repo')
+    await writeFile(sitePath, custom, 'utf8')
+
+    await initBlank(projectRoot, ['--presentation-id', '2026-second', '--title', 'Second', '--from-date', '2026-02-01'])
+
+    expect(await readText(sitePath)).toContain('https://example.com/custom-repo')
+  })
+
+  it('fails from-example when content exists without force and overwrites with force', async () => {
+    const projectRoot = await createProjectRoot('init-example-force')
+    await initBlank(projectRoot, ['--presentation-id', 'seed', '--title', 'Seed', '--from-date', '2026-01-01'])
+
+    const fail = await runCli(['init', projectRoot, '--from-example', 'open-source-update'])
+    await writeFile(projectPath(projectRoot, 'content', 'marker.txt'), 'remove-me', 'utf8')
+    const pass = await runCli(['init', projectRoot, '--from-example', 'open-source-update', '--force'])
+
+    expect(fail.status).toBe(1)
+    expect(fail.stderr).toContain('content/ already exists. Use --force to overwrite.')
+    expect(pass.status).toBe(0)
+    expect(await readText(projectPath(projectRoot, 'content', 'site.yaml'))).toContain('Vortex CLI Updates')
+    expect(await readText(projectPath(projectRoot, 'content', 'presentations', 'index.yaml'))).toContain('2026-q1')
+  })
+
+  it('retries invalid example id in from-example prompt and succeeds with valid id', async () => {
+    const projectRoot = await createProjectRoot('init-example-retry')
+    const result = await runCli(['init', projectRoot, '--from-example'], {
+      inputLines: ['not-a-real-example', 'product-review'],
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Unknown example "not-a-real-example". Valid IDs:')
+    expect(await readText(projectPath(projectRoot, 'content', 'site.yaml'))).toContain('Meridian')
+  })
+
+  it('supports spaces in project roots and uses cwd as default project root', async () => {
+    const parent = await createProjectRoot('init-space-parent')
+    const projectRoot = projectPath(parent, 'project with spaces')
+    const cwdRoot = await createProjectRoot('init-cwd-default')
+    await mkdir(projectRoot, { recursive: true })
+    const spaceResult = await runCli([
+      'init', projectRoot, '--presentation-id', 'space-path', '--title', 'Space Path', '--from-date', '2026-01-01',
+    ])
+    const cwdResult = await runCli(
+      ['init', '--presentation-id', 'cwd-default', '--title', 'Cwd Default', '--from-date', '2026-01-01'],
+      { cwd: cwdRoot },
+    )
+
+    expect(spaceResult.status).toBe(0)
+    expect(cwdResult.status).toBe(0)
+    expect(await readText(projectPath(projectRoot, 'content', 'presentations', 'space-path', 'presentation.yaml'))).toContain('presentation:')
+    expect(await readText(projectPath(cwdRoot, 'content', 'presentations', 'cwd-default', 'generated.yaml'))).toContain('generated:')
+  })
+
+  it('rejects malformed and inverted reporting periods during init', async () => {
+    const projectRoot = await createProjectRoot('init-invalid-dates')
+    const malformed = await runCli([
+      'init', projectRoot, '--presentation-id', 'bad-date', '--title', 'Bad Date', '--from-date', '01-01-2026',
+    ])
+    const inverted = await runCli([
+      'init', projectRoot, '--presentation-id', 'bad-range', '--title', 'Bad Range', '--from-date', '2026-03-01', '--to-date', '2026-01-01',
+    ])
+
+    expect(malformed.status).toBe(1)
+    expect(malformed.stderr).toContain('fromDate must be in YYYY-MM-DD format.')
+    expect(inverted.status).toBe(1)
+    expect(inverted.stderr).toContain('fromDate must be on or before toDate.')
+  })
+
+  it('rejects presentation ids that are not path-safe', async () => {
+    const projectRoot = await createProjectRoot('init-invalid-id')
+    const result = await runCli([
+      'init', projectRoot, '--presentation-id', '../escape', '--title', 'Escape', '--from-date', '2026-01-01',
+    ])
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('presentationId must be path-safe')
+  })
+})

--- a/cli/e2e/cli.init.e2e.spec.ts
+++ b/cli/e2e/cli.init.e2e.spec.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createTempDirectory, projectPath, readYamlFile, removePath, runCli } from './cli-e2e-helpers'
+
+interface SiteDocument {
+  readonly site: {
+    readonly data_sources?: Array<{ type: string; url: string }>
+    readonly links: {
+      readonly repository: { url: string }
+      readonly docs: { url: string }
+      readonly community: { url: string }
+    }
+  }
+}
+
+interface PresentationIndexDocument {
+  readonly presentations: Array<{
+    readonly id: string
+    readonly title: string
+    readonly subtitle: string
+    readonly summary: string
+    readonly featured: boolean
+  }>
+}
+
+interface PresentationDocument {
+  readonly presentation: {
+    readonly title?: string
+    readonly subtitle?: string
+    readonly summary?: string
+    readonly slides: unknown[]
+  }
+}
+
+interface GeneratedDocument {
+  readonly generated: {
+    readonly id: string
+    readonly period: {
+      readonly start: string
+      readonly end: string
+    }
+  }
+}
+
+const cleanupPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => removePath(path)))
+})
+
+async function createProjectRoot(name: string): Promise<string> {
+  const projectRoot = await createTempDirectory(name)
+  cleanupPaths.push(projectRoot)
+  return projectRoot
+}
+
+describe('built CLI init e2e', () => {
+  it('scaffolds a blank project with every init flag and preserves documented defaults', async () => {
+    const projectRoot = await createProjectRoot('init-all-flags')
+    const result = await runCli([
+      'init',
+      '--project-root',
+      projectRoot,
+      '--presentation-id',
+      '2026-spring',
+      '--title',
+      'Spring Product Brief',
+      '--subtitle',
+      'Spring 2026',
+      '--from-date',
+      '2026-03-01',
+      '--to-date',
+      '2026-05-31',
+      '--summary',
+      'Spring release and community update.',
+      '--repository-url',
+      'https://github.com/lreading/slide-spec',
+      '--docs-url',
+      'https://www.slide-spec.dev/',
+      '--website-url',
+      'https://example.com/community',
+      '--github-data-source-url',
+      'https://github.com/lreading/slide-spec',
+      '--force',
+    ])
+    const site = await readYamlFile<SiteDocument>(projectPath(projectRoot, 'content', 'site.yaml'))
+    const index = await readYamlFile<PresentationIndexDocument>(
+      projectPath(projectRoot, 'content', 'presentations', 'index.yaml'),
+    )
+    const presentation = await readYamlFile<PresentationDocument>(
+      projectPath(projectRoot, 'content', 'presentations', '2026-spring', 'presentation.yaml'),
+    )
+    const generated = await readYamlFile<GeneratedDocument>(
+      projectPath(projectRoot, 'content', 'presentations', '2026-spring', 'generated.yaml'),
+    )
+
+    expect(result.stdout).toContain('Initialized 2026-spring')
+    expect(site.site.links.repository.url).toBe('https://github.com/lreading/slide-spec')
+    expect(site.site.links.docs.url).toBe('https://www.slide-spec.dev/')
+    expect(site.site.links.community.url).toBe('https://example.com/community')
+    expect(site.site.data_sources).toEqual([{ type: 'github', url: 'https://github.com/lreading/slide-spec' }])
+    expect(index.presentations[0]).toMatchObject({
+      id: '2026-spring',
+      title: 'Spring Product Brief',
+      subtitle: 'Spring 2026',
+      summary: 'Spring release and community update.',
+      featured: true,
+    })
+    expect(presentation.presentation.slides.length).toBeGreaterThan(5)
+    expect(generated.generated.period).toEqual({ start: '2026-03-01', end: '2026-05-31' })
+  })
+
+  it('scaffolds init with only required flags and default placeholder fields', async () => {
+    const projectRoot = await createProjectRoot('init-required')
+    const result = await runCli([
+      'init',
+      projectRoot,
+      '--presentation-id',
+      '2026-minimal',
+      '--title',
+      'Minimal Brief',
+      '--from-date',
+      '2026-01-15',
+    ])
+    const site = await readYamlFile<SiteDocument>(projectPath(projectRoot, 'content', 'site.yaml'))
+    const index = await readYamlFile<PresentationIndexDocument>(
+      projectPath(projectRoot, 'content', 'presentations', 'index.yaml'),
+    )
+    const generated = await readYamlFile<GeneratedDocument>(
+      projectPath(projectRoot, 'content', 'presentations', '2026-minimal', 'generated.yaml'),
+    )
+
+    expect(result.status).toBe(0)
+    expect(site.site.data_sources).toBeUndefined()
+    expect(site.site.links.repository.url).toBe('https://example.com/repository')
+    expect(index.presentations[0]?.summary).toBe('Replace with a summary before publishing.')
+    expect(index.presentations[0]?.subtitle).toBe('Replace with a subtitle before publishing.')
+    expect(generated.generated.id).toBe('2026-minimal')
+  })
+
+  it.each([
+    ['--presentation-id', ['--title', 'Missing ID', '--from-date', '2026-01-01']],
+    ['--title', ['--presentation-id', 'missing-title', '--from-date', '2026-01-01']],
+    ['--from-date', ['--presentation-id', 'missing-date', '--title', 'Missing Date']],
+  ])('rejects init when %s is missing', async (flag, args) => {
+    const projectRoot = await createProjectRoot('init-missing')
+    const result = await runCli(['init', projectRoot, ...args])
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain(`Missing required option: ${flag}.`)
+  })
+
+  it('runs the full interactive blank init flow', async () => {
+    const projectRoot = await createProjectRoot('interactive-init')
+    const result = await runCli(['init'], {
+      inputLines: [
+        'n',
+        projectRoot,
+        'interactive-brief',
+        'Interactive Brief',
+        '',
+        '2026-04-01',
+        '',
+        'Interactive summary.',
+        'n',
+        'https://github.com/lreading/slide-spec',
+        '',
+        '',
+        'n',
+        'n',
+      ],
+    })
+    const index = await readYamlFile<PresentationIndexDocument>(
+      projectPath(projectRoot, 'content', 'presentations', 'index.yaml'),
+    )
+
+    expect(result.status).toBe(0)
+    expect(index.presentations[0]?.id).toBe('interactive-brief')
+    expect(index.presentations[0]?.summary).toBe('Interactive summary.')
+  })
+})

--- a/cli/e2e/cli.interactive-init-serve.e2e.spec.ts
+++ b/cli/e2e/cli.interactive-init-serve.e2e.spec.ts
@@ -1,0 +1,89 @@
+import { spawn } from 'node:child_process'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { cliBin, createTempDirectory, projectPath, readText, removePath } from './cli-e2e-helpers'
+
+const cleanupPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => removePath(path)))
+})
+
+async function createProjectRoot(name: string): Promise<string> {
+  const projectRoot = await createTempDirectory(name)
+  cleanupPaths.push(projectRoot)
+  return projectRoot
+}
+
+async function runInteractiveInitAndServe(projectRoot: string): Promise<{ output: string; stop(): Promise<void> }> {
+  const child = spawn(process.execPath, [cliBin, 'init'], { stdio: 'pipe' })
+  const answers = new Map<string, string>([
+    ['Start from an example (y/N):', 'n'],
+    ['Project root (optional):', projectRoot],
+    ['Presentation id:', 'post-init-serve'],
+    ['Title:', 'Post Init Serve'],
+    ['Subtitle (optional):', ''],
+    ['From date (YYYY-MM-DD):', '2026-04-01'],
+    ['To date (YYYY-MM-DD, optional):', ''],
+    ['Summary (optional):', ''],
+    ['Import GitHub statistics (y/N):', 'n'],
+    ['Repository URL (optional):', ''],
+    ['Docs URL (optional):', ''],
+    ['Website URL (optional):', ''],
+    ['Overwrite existing scaffold files (y/N):', 'n'],
+    ['Start local server (Y/n):', 'y'],
+  ])
+  const sent = new Set<string>()
+  let output = ''
+
+  return new Promise((resolvePromise, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`Interactive init serve timed out:\n${output}`))
+    }, 45000)
+    const onData = (chunk: Buffer): void => {
+      output += chunk.toString('utf8')
+      for (const [prompt, answer] of answers) {
+        if (!sent.has(prompt) && output.includes(prompt)) {
+          sent.add(prompt)
+          child.stdin.write(`${answer}\n`)
+        }
+      }
+      if (/Serving at http:\/\/127\.0\.0\.1:\d+\//.test(output)) {
+        clearTimeout(timeout)
+        resolvePromise({
+          output,
+          stop: async () => {
+            child.kill('SIGTERM')
+            await new Promise<void>((resolve) => child.once('close', () => resolve()))
+          },
+        })
+      }
+    }
+
+    child.stdout.on('data', onData)
+    child.stderr.on('data', onData)
+    child.on('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+  })
+}
+
+describe('built CLI interactive init server e2e', () => {
+  it('starts the local server after interactive init when requested', async () => {
+    const projectRoot = await createProjectRoot('interactive-init-serve')
+    const serve = await runInteractiveInitAndServe(projectRoot)
+    const url = serve.output.match(/Serving at (http:\/\/127\.0\.0\.1:\d+\/)/)?.[1]
+
+    try {
+      expect(url).toBeDefined()
+      expect(await readText(projectPath(projectRoot, 'content', 'presentations', 'post-init-serve', 'generated.yaml'))).toContain('generated:')
+      const response = await fetch(url as string)
+      expect(response.status).toBe(200)
+    } finally {
+      await serve.stop()
+    }
+  })
+})

--- a/cli/e2e/cli.interactive.e2e.spec.ts
+++ b/cli/e2e/cli.interactive.e2e.spec.ts
@@ -1,0 +1,188 @@
+import { spawn } from 'node:child_process'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { cliBin, createTempDirectory, projectPath, readText, removePath, runCli } from './cli-e2e-helpers'
+
+const cleanupPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => removePath(path)))
+})
+
+async function createProjectRoot(name: string): Promise<string> {
+  const projectRoot = await createTempDirectory(name)
+  cleanupPaths.push(projectRoot)
+  return projectRoot
+}
+
+async function initProject(projectRoot: string, withSource = false): Promise<void> {
+  const result = await runCli([
+    'init',
+    projectRoot,
+    '--presentation-id',
+    '2026-q1',
+    '--title',
+    'Interactive Matrix',
+    '--from-date',
+    '2026-01-01',
+    ...(withSource ? ['--github-data-source-url', 'https://github.com/lreading/slide-spec'] : []),
+    '--force',
+  ])
+  expect(result.status).toBe(0)
+}
+
+async function startInteractiveServe(projectRoot: string): Promise<{ output: string; stop(): Promise<void> }> {
+  const child = spawn(process.execPath, [cliBin], { stdio: 'pipe' })
+  let output = ''
+  const sent = new Set<string>()
+
+  return new Promise((resolvePromise, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM')
+      reject(new Error(`Interactive serve timed out:\n${output}`))
+    }, 45000)
+    const answer = (key: string, pattern: string, value: string): void => {
+      if (!sent.has(key) && output.includes(pattern)) {
+        sent.add(key)
+        child.stdin.write(`${value}\n`)
+      }
+    }
+    const onData = (chunk: Buffer): void => {
+      output += chunk.toString('utf8')
+      answer('command', 'Command (init, fetch, build, serve, validate, help):', 'serve')
+      answer('root', 'Project root (optional):', projectRoot)
+      answer('host', 'Host (optional):', '')
+      answer('port', 'Port [5173]:', '0')
+      answer('open', 'Open in browser (y/N):', 'n')
+      if (/Serving at http:\/\/127\.0\.0\.1:\d+\//.test(output)) {
+        clearTimeout(timeout)
+        resolvePromise({
+          output,
+          stop: async () => {
+            child.kill('SIGTERM')
+            await new Promise<void>((resolve) => child.once('close', () => resolve()))
+          },
+        })
+      }
+    }
+
+    child.stdout.on('data', onData)
+    child.stderr.on('data', onData)
+    child.on('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.on('close', (status) => {
+      if (!/Serving at http:\/\/127\.0\.0\.1:\d+\//.test(output)) {
+        clearTimeout(timeout)
+        reject(new Error(`Interactive serve exited with ${status}:\n${output}`))
+      }
+    })
+  })
+}
+
+describe('built CLI root interactive e2e', () => {
+  it('prints help when the user chooses help', async () => {
+    const result = await runCli([], { inputLines: ['help'] })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('No command provided. Starting interactive mode.')
+    expect(result.stdout).toContain('Usage: slide-spec <command> [options]')
+  })
+
+  it('runs validate, build, fetch, and init from root interactive command selection', async () => {
+    const validateRoot = await createProjectRoot('interactive-validate')
+    const buildRoot = await createProjectRoot('interactive-build')
+    const fetchRoot = await createProjectRoot('interactive-fetch')
+    const initRoot = await createProjectRoot('interactive-init-root')
+    await initProject(validateRoot)
+    await initProject(buildRoot)
+    await initProject(fetchRoot)
+    await removePath(projectPath(fetchRoot, 'content', 'presentations', '2026-q1', 'generated.yaml'))
+
+    const validate = await runCli([], { inputLines: ['validate', validateRoot, 'y'] })
+    const build = await runCli([], { inputLines: ['build', buildRoot, ''] },)
+    const fetch = await runCli([], {
+      inputLines: ['fetch', fetchRoot, '2026-q1', '2026-01-01', '', 'n', 'n', 'n'],
+    })
+    const init = await runCli([], {
+      inputLines: [
+        'init',
+        'n',
+        initRoot,
+        'interactive-created',
+        'Interactive Created',
+        '',
+        '2026-02-01',
+        '',
+        '',
+        'n',
+        '',
+        '',
+        '',
+        'n',
+        'n',
+      ],
+    })
+
+    expect(validate.status).toBe(0)
+    expect(validate.stdout).toContain('Content is valid')
+    expect(build.status).toBe(0)
+    expect(build.stdout).toContain(projectPath(buildRoot, 'dist'))
+    expect(fetch.status).toBe(1)
+    expect(fetch.stderr).toContain('site.data_sources must include exactly one github source.')
+    expect(init.status).toBe(0)
+    await expect(readText(projectPath(initRoot, 'content', 'presentations', 'interactive-created', 'generated.yaml'))).resolves.toContain('generated:')
+  })
+
+  it('runs interactive init GitHub import retry and writes a redacted PAT file', async () => {
+    const projectRoot = await createProjectRoot('interactive-init-github')
+    const result = await runCli(['init'], {
+      inputLines: [
+        'init',
+        'n',
+        projectRoot,
+        'github-import',
+        'GitHub Import',
+        '',
+        '2026-03-01',
+        '',
+        '',
+        'y',
+        'https://github.com/lreading/definitely-not-a-real-slide-spec-repo',
+        'https://github.com/lreading/slide-spec',
+        'y',
+        'fake-secret-token',
+        '',
+        '',
+        '',
+        'n',
+        'n',
+      ],
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout + result.stderr).toContain('was not found. Double-check the URL and try again.')
+    expect(result.stdout).toContain('Wrote GitHub PAT to .env.')
+    expect(result.stdout).not.toContain('fake-secret-token')
+    await expect(readText(projectPath(projectRoot, '.env'))).resolves.toContain('GITHUB_PAT=fake-secret-token')
+    await expect(readText(projectPath(projectRoot, 'content', 'site.yaml'))).resolves.toContain('https://github.com/lreading/slide-spec')
+  })
+
+  it('runs serve from root interactive command selection', async () => {
+    const projectRoot = await createProjectRoot('interactive-serve')
+    await initProject(projectRoot)
+    const serve = await startInteractiveServe(projectRoot)
+    const url = serve.output.match(/Serving at (http:\/\/127\.0\.0\.1:\d+\/)/)?.[1]
+
+    try {
+      expect(url).toBeDefined()
+      const response = await fetch(url as string)
+      expect(response.status).toBe(200)
+      await expect(response.text()).resolves.toContain('<div id="app"></div>')
+    } finally {
+      await serve.stop()
+    }
+  })
+})

--- a/cli/e2e/cli.runtime.e2e.spec.ts
+++ b/cli/e2e/cli.runtime.e2e.spec.ts
@@ -1,0 +1,151 @@
+import { createServer, type Server } from 'node:http'
+import { writeFile } from 'node:fs/promises'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createTempDirectory, projectPath, readText, removePath, runCli, startCliUntil } from './cli-e2e-helpers'
+
+const cleanupPaths: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => removePath(path)))
+})
+
+async function createProjectRoot(name: string): Promise<string> {
+  const projectRoot = await createTempDirectory(name)
+  cleanupPaths.push(projectRoot)
+  return projectRoot
+}
+
+async function initBlankProject(projectRoot: string): Promise<void> {
+  const result = await runCli([
+    'init',
+    projectRoot,
+    '--presentation-id',
+    '2026-q1',
+    '--title',
+    'Quarterly Update',
+    '--from-date',
+    '2026-03-01',
+    '--to-date',
+    '2026-05-31',
+    '--force',
+  ])
+  expect(result.status).toBe(0)
+}
+
+async function breakContentYaml(projectRoot: string): Promise<void> {
+  const filePath = projectPath(projectRoot, 'content', 'presentations', 'index.yaml')
+  await writeFile(filePath, 'schemaVersion: [\n', 'utf8')
+}
+
+function getServeUrl(output: string): string {
+  const match = output.match(/Serving at (http:\/\/127\.0\.0\.1:\d+\/)$/m)
+  if (!match) {
+    throw new Error(`Missing serve URL in output:\n${output}`)
+  }
+  return match[1] as string
+}
+
+async function serveAndFetch(args: string[], cwd?: string): Promise<string> {
+  const serve = await startCliUntil(
+    args,
+    /Serving at http:\/\/127\.0\.0\.1:\d+\//,
+    cwd === undefined ? {} : { cwd },
+  )
+  try {
+    const response = await fetch(getServeUrl(serve.stdout() + serve.stderr()))
+    const html = await response.text()
+    expect(response.status).toBe(200)
+    expect(html).toContain('<div id="app"></div>')
+    return serve.stdout() + serve.stderr()
+  } finally {
+    await serve.stop()
+  }
+}
+
+describe('built CLI runtime e2e', () => {
+  it('build supports cwd default, paths with spaces, positional and --project-root', async () => {
+    const cwdProject = await createProjectRoot('build-cwd')
+    const spacedProject = await createProjectRoot('build path with spaces')
+    const projectRootFlagProject = await createProjectRoot('build-project-root-flag')
+    await Promise.all([initBlankProject(cwdProject), initBlankProject(spacedProject), initBlankProject(projectRootFlagProject)])
+
+    const cwdBuild = await runCli(['build'], { cwd: cwdProject, timeoutMs: 90000 })
+    const spacedBuild = await runCli(['build', spacedProject], { timeoutMs: 90000 })
+    const rootFlagBuild = await runCli(['build', '--project-root', projectRootFlagProject], { timeoutMs: 90000 })
+
+    expect(cwdBuild.status).toBe(0)
+    expect(spacedBuild.status).toBe(0)
+    expect(rootFlagBuild.status).toBe(0)
+    await expect(readText(projectPath(cwdProject, 'dist', 'index.html'))).resolves.toContain('Slide Spec')
+    await expect(readText(projectPath(spacedProject, 'dist', 'index.html'))).resolves.toContain('Slide Spec')
+    await expect(readText(projectPath(projectRootFlagProject, 'dist', 'index.html'))).resolves.toContain('Slide Spec')
+  })
+
+  it('build writes deployment URL into generated index metadata', async () => {
+    const projectRoot = await createProjectRoot('build-deployment-url')
+    await initBlankProject(projectRoot)
+
+    const result = await runCli(
+      ['build', projectRoot, '--deployment-url', 'https://updates.example.com/slides'],
+      { timeoutMs: 90000 },
+    )
+
+    expect(result.status).toBe(0)
+    await expect(readText(projectPath(projectRoot, 'dist', 'index.html'))).resolves.toContain(
+      'https://updates.example.com/slides/',
+    )
+  })
+
+  it('build fails for invalid content and does not emit usable dist', async () => {
+    const projectRoot = await createProjectRoot('build-invalid-content')
+    await initBlankProject(projectRoot)
+    await breakContentYaml(projectRoot)
+
+    const result = await runCli(['build', projectRoot], { timeoutMs: 90000 })
+
+    expect(result.status).toBe(1)
+    expect(result.stdout + result.stderr).toContain('schemaVersion')
+  })
+
+  it('serve responds over HTTP for explicit root and cwd default', async () => {
+    const explicitProject = await createProjectRoot('serve-http-explicit')
+    const cwdProject = await createProjectRoot('serve-http-cwd')
+    await Promise.all([initBlankProject(explicitProject), initBlankProject(cwdProject)])
+
+    await expect(serveAndFetch(['serve', explicitProject, '--port', '0'])).resolves.toContain('Serving at http://127.0.0.1:')
+    await expect(serveAndFetch(['serve', '--port', '0'], cwdProject)).resolves.toContain('Serving at http://127.0.0.1:')
+  })
+
+  it('serve with explicit busy port exits 1 with busy-port error', async () => {
+    const projectRoot = await createProjectRoot('serve-busy-port')
+    await initBlankProject(projectRoot)
+
+    const blocker: Server = await new Promise((resolve) => {
+      const server = createServer((_request, response) => response.end('busy'))
+      server.listen(0, '127.0.0.1', () => resolve(server))
+    })
+
+    try {
+      const address = blocker.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+      const result = await runCli(['serve', projectRoot, '--host', '127.0.0.1', '--port', String(port)])
+
+      expect(result.status).toBe(1)
+      expect(result.stdout + result.stderr).toMatch(/EADDRINUSE|already in use|address in use/i)
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()))
+    }
+  })
+
+  it('serve fails for invalid content', async () => {
+    const projectRoot = await createProjectRoot('serve-invalid-content')
+    await initBlankProject(projectRoot)
+    await breakContentYaml(projectRoot)
+
+    const result = await runCli(['serve', projectRoot, '--port', '0'])
+
+    expect(result.status).toBe(1)
+  })
+})

--- a/cli/package.json
+++ b/cli/package.json
@@ -39,14 +39,16 @@
     "cli": "node --import tsx src/index.ts",
     "build": "node --import tsx scripts/sync-runtime-template.ts --out runtime-template && node --import tsx scripts/sync-examples.ts --out examples-synced && node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && esbuild src/index.ts --bundle --platform=node --format=esm --target=es2022 --packages=external --outfile=dist/index.js && node --import tsx scripts/sync-runtime-template.ts --out dist/runtime-template && node --import tsx scripts/sync-examples.ts --out dist/examples",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "lint": "eslint --cache --cache-location .eslintcache --max-warnings=0 \"src/**/*.ts\" vitest.config.ts eslint.config.mjs",
-    "lint:fix": "eslint --cache --cache-location .eslintcache --fix \"src/**/*.ts\" vitest.config.ts eslint.config.mjs",
+    "lint": "eslint --cache --cache-location .eslintcache --max-warnings=0 \"src/**/*.ts\" \"e2e/**/*.ts\" vitest.config.ts vitest.e2e.config.ts vitest.connectors-e2e.config.ts eslint.config.mjs",
+    "lint:fix": "eslint --cache --cache-location .eslintcache --fix \"src/**/*.ts\" \"e2e/**/*.ts\" vitest.config.ts vitest.e2e.config.ts vitest.connectors-e2e.config.ts eslint.config.mjs",
     "semgrep": "node --import tsx scripts/run-semgrep.ts",
     "spellcheck": "pnpm exec cspell lint --no-progress \"../README.md\" \"../CONTRIBUTING.md\" \"../docs/**/*.md\" --gitignore --config ../.cspell.json",
     "test": "vitest run",
+    "e2e": "pnpm run build && vitest run --config vitest.e2e.config.ts",
+    "e2e:connectors": "pnpm run build && vitest run --config vitest.connectors-e2e.config.ts",
     "coverage": "vitest run --coverage --coverage.thresholds.perFile=true --coverage.thresholds.statements=80 --coverage.thresholds.branches=80 --coverage.thresholds.functions=80 --coverage.thresholds.lines=80",
-    "verify": "pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run build && pnpm run spellcheck",
-    "verify:ci": "pnpm run lint && pnpm run typecheck && pnpm run build"
+    "verify": "pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run e2e && pnpm run spellcheck",
+    "verify:ci": "pnpm run lint && pnpm run typecheck && pnpm run e2e"
   },
   "dependencies": {
     "@fontsource/poppins": "catalog:",

--- a/cli/src/application/TdCliApplicationService.spec.ts
+++ b/cli/src/application/TdCliApplicationService.spec.ts
@@ -548,6 +548,23 @@ describe('TdCliApplicationService', () => {
     expect(presentationIndexStore.writes).toHaveLength(0)
   })
 
+  it('rejects presentation ids that cannot be used as safe scaffold path segments', async () => {
+    const service = new TdCliApplicationService({
+      projectRoot: '/repo',
+      presentationIndexStore: new StubPresentationIndexStore([]) as never,
+      reportingPeriodResolver: new StubReportingPeriodResolver() as never,
+      fileSystem: new MemoryFileSystem(),
+    })
+
+    await expect(service.initPresentation({
+      presentationId: '../escape',
+      title: 'Escape',
+      fromDate: '2026-01-01',
+    })).rejects.toThrow(
+      'presentationId must be path-safe and contain only letters, numbers, dots, underscores, and hyphens.',
+    )
+  })
+
   it('initFromExample copies the example content to the target project root', async () => {
     const fileSystem = new TrackingFileSystem()
     const exampleRegistry = new StubExampleRegistry()
@@ -671,6 +688,36 @@ describe('TdCliApplicationService', () => {
     })
 
     expect(contentValidator.validates).toEqual(['/repo'])
+    expect(devSiteServer.starts).toEqual([
+      {
+        root: '/repo',
+        host: '127.0.0.1',
+        port: 5173,
+      },
+      {
+        root: '/repo',
+        host: '127.0.0.1',
+        port: 0,
+      },
+    ])
+  })
+
+  it('falls back when Vite reports the default serve port is busy without an error code', async () => {
+    const contentValidator = new StubContentValidator()
+    const devSiteServer = new StubViteSiteDevServer({
+      startErrors: [new Error('Port 5173 is already in use')],
+      startResults: [58124],
+    })
+    const service = new TdCliApplicationService({
+      projectRoot: '/repo',
+      devSiteServer: devSiteServer as never,
+      contentValidator: contentValidator as never,
+    })
+
+    await expect(service.serveSite({})).resolves.toEqual({
+      url: 'http://127.0.0.1:58124/',
+    })
+
     expect(devSiteServer.starts).toEqual([
       {
         root: '/repo',

--- a/cli/src/application/TdCliApplicationService.ts
+++ b/cli/src/application/TdCliApplicationService.ts
@@ -113,6 +113,7 @@ export class TdCliApplicationService implements TdCliService {
   }
 
   public async initPresentation(input: InitPresentationInput): Promise<InitPresentationResult> {
+    this.validatePresentationId(input.presentationId)
     const paths = this.getPaths(input.projectRoot)
     const createdPaths: string[] = []
     const period = this.reportingPeriodResolver.resolve(input.fromDate, input.toDate).current
@@ -314,7 +315,20 @@ export class TdCliApplicationService implements TdCliService {
     return new FileSystemPaths(projectRoot ?? this.defaultProjectRoot)
   }
 
+  private validatePresentationId(presentationId: string): void {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(presentationId)) {
+      throw new Error(
+        'presentationId must be path-safe and contain only letters, numbers, dots, underscores, and hyphens.',
+      )
+    }
+  }
+
   private isAddressInUseError(error: unknown): error is NodeJS.ErrnoException {
-    return error instanceof Error && 'code' in error && error.code === 'EADDRINUSE'
+    const message = error instanceof Error ? error.message : String(error)
+
+    return (
+      (typeof error === 'object' && error !== null && 'code' in error && error.code === 'EADDRINUSE')
+      || /port \d+ is already in use/i.test(message)
+    )
   }
 }

--- a/cli/src/commands/CliCommandRunner.spec.ts
+++ b/cli/src/commands/CliCommandRunner.spec.ts
@@ -113,6 +113,14 @@ describe('CliCommandRunner', () => {
       '2026-03-31',
       '--summary',
       'Summary',
+      '--repository-url',
+      'https://github.com/lreading/slide-spec',
+      '--docs-url',
+      'https://www.slide-spec.dev/',
+      '--website-url',
+      'https://example.com',
+      '--github-data-source-url',
+      'https://github.com/lreading/slide-spec',
       '--force',
     ])).resolves.toBe(0)
 
@@ -123,6 +131,10 @@ describe('CliCommandRunner', () => {
       fromDate: '2026-01-01',
       toDate: '2026-03-31',
       summary: 'Summary',
+      repositoryUrl: 'https://github.com/lreading/slide-spec',
+      docsUrl: 'https://www.slide-spec.dev/',
+      websiteUrl: 'https://example.com',
+      githubDataSourceUrl: 'https://github.com/lreading/slide-spec',
       force: true,
     })
     expect(output.info).toHaveBeenCalledWith('Initialized 2026-q1')

--- a/cli/src/commands/CliCommandRunner.ts
+++ b/cli/src/commands/CliCommandRunner.ts
@@ -290,6 +290,10 @@ export class CliCommandRunner {
     const toDate = this.readStringOption(parsed.options, 'to-date')
     const summary = this.readStringOption(parsed.options, 'summary')
     const subtitle = this.readStringOption(parsed.options, 'subtitle')
+    const repositoryUrl = this.readStringOption(parsed.options, 'repository-url')
+    const docsUrl = this.readStringOption(parsed.options, 'docs-url')
+    const websiteUrl = this.readStringOption(parsed.options, 'website-url')
+    const githubDataSourceUrl = this.readStringOption(parsed.options, 'github-data-source-url')
     const result = await this.service.initPresentation({
       ...(projectRoot !== undefined ? { projectRoot } : {}),
       presentationId: required['presentation-id'],
@@ -299,6 +303,10 @@ export class CliCommandRunner {
       ...(toDate !== undefined ? { toDate } : {}),
       ...(summary !== undefined ? { summary } : {}),
       ...(force !== undefined ? { force } : {}),
+      ...(repositoryUrl !== undefined ? { repositoryUrl } : {}),
+      ...(docsUrl !== undefined ? { docsUrl } : {}),
+      ...(websiteUrl !== undefined ? { websiteUrl } : {}),
+      ...(githubDataSourceUrl !== undefined ? { githubDataSourceUrl } : {}),
     })
     this.info(`Initialized ${result.presentationId}`)
   }
@@ -559,7 +567,7 @@ export class CliCommandRunner {
           'Options:',
           '  [project-root]          Optional. Positional presentation project root',
           '  --project-root <path>   Optional. Named presentation project root',
-          '  --presentation-id <id>        Required. Unique presentation id used for content/presentations/<id>/',
+          '  --presentation-id <id>        Required. Unique path-safe presentation id used for content/presentations/<id>/',
           '  --title <title>               Required. Presentation title shown in listings and the app',
           '  --subtitle <subtitle>         Optional. Secondary label shown in listings and slide chrome',
           '  --from-date <date>            Required. Period start date in YYYY-MM-DD format',
@@ -584,7 +592,7 @@ export class CliCommandRunner {
           'Pull GitHub-derived metrics and write generated data for an existing presentation.',
           'Use this after init, once the presentation scaffold exists.',
           'If generated.yaml already exists, the command exits with an error. Use --force to overwrite.',
-          'If no PAT is available, the CLI will continue best-effort and may be rate-limited.',
+          'If no GitHub token is available, the CLI will continue best-effort and may be rate-limited.',
           'Large repositories can take up to about two minutes before the CLI falls back on unavailable snapshot metadata.',
           '',
           globalOptions,

--- a/cli/src/config/EnvLoader.spec.ts
+++ b/cli/src/config/EnvLoader.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { EnvLoader } from './EnvLoader'
 import { FileSystemPaths } from '../io/FileSystemPaths'
@@ -33,8 +33,50 @@ class MemoryFileSystem implements FileSystem {
   public async removeDirectory(_path: string): Promise<void> {}
 }
 
+let previousGitHubPat: string | undefined
+let previousGitHubToken: string | undefined
+let previousGhToken: string | undefined
+
+beforeEach(() => {
+  previousGitHubPat = process.env.GITHUB_PAT
+  previousGitHubToken = process.env.GITHUB_TOKEN
+  previousGhToken = process.env.GH_TOKEN
+  delete process.env.GITHUB_PAT
+  delete process.env.GITHUB_TOKEN
+  delete process.env.GH_TOKEN
+})
+
+afterEach(() => {
+  restoreEnvValue('GITHUB_PAT', previousGitHubPat)
+  restoreEnvValue('GITHUB_TOKEN', previousGitHubToken)
+  restoreEnvValue('GH_TOKEN', previousGhToken)
+})
+
+function restoreEnvValue(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name]
+    return
+  }
+
+  process.env[name] = value
+}
+
 describe('EnvLoader', () => {
-  it('loads the GitHub token from GITHUB_PAT and falls back to GITHUB_TOKEN', async () => {
+  it('loads the GitHub token from environment variables before .env files', async () => {
+    const paths = new FileSystemPaths('/workspace/project')
+
+    process.env.GITHUB_PAT = 'process-token'
+
+    await expect(
+      new EnvLoader(new MemoryFileSystem({
+        '/workspace/project/.env': 'GITHUB_PAT=file-token',
+      })).loadEnvironment(paths),
+    ).resolves.toEqual({
+      githubAccessToken: 'process-token',
+    })
+  })
+
+  it('loads the GitHub token from GITHUB_PAT and falls back to GITHUB_TOKEN or GH_TOKEN', async () => {
     const paths = new FileSystemPaths('/workspace/project')
     const loader = new EnvLoader(new MemoryFileSystem({
       '/workspace/project/.env': 'GITHUB_PAT=test-token',
@@ -50,6 +92,14 @@ describe('EnvLoader', () => {
       })).loadEnvironment(paths),
     ).resolves.toEqual({
       githubAccessToken: 'fallback-token',
+    })
+
+    await expect(
+      new EnvLoader(new MemoryFileSystem({
+        '/workspace/project/.env': 'GH_TOKEN=actions-token',
+      })).loadEnvironment(paths),
+    ).resolves.toEqual({
+      githubAccessToken: 'actions-token',
     })
   })
 

--- a/cli/src/config/EnvLoader.ts
+++ b/cli/src/config/EnvLoader.ts
@@ -10,6 +10,14 @@ export class EnvLoader {
   public constructor(private readonly fileSystem: FileSystem = new NodeFileSystem()) {}
 
   public async loadEnvironment(paths: FileSystemPaths): Promise<CliEnvironment> {
+    const processToken = this.readGitHubToken(process.env)
+
+    if (processToken) {
+      return {
+        githubAccessToken: processToken,
+      }
+    }
+
     const envPath = await this.findEnvPath(paths)
 
     if (!envPath) {
@@ -18,7 +26,7 @@ export class EnvLoader {
 
     const envSource = await this.fileSystem.readTextFile(envPath)
     const parsed = parse(envSource)
-    const githubAccessToken = parsed.GITHUB_PAT?.trim() || parsed.GITHUB_TOKEN?.trim()
+    const githubAccessToken = this.readGitHubToken(parsed)
 
     if (!githubAccessToken) {
       return {}
@@ -39,5 +47,9 @@ export class EnvLoader {
     }
 
     return undefined
+  }
+
+  private readGitHubToken(source: Record<string, string | undefined>): string | undefined {
+    return source.GITHUB_PAT?.trim() || source.GITHUB_TOKEN?.trim() || source.GH_TOKEN?.trim() || undefined
   }
 }

--- a/cli/src/logging/LogSanitizer.spec.ts
+++ b/cli/src/logging/LogSanitizer.spec.ts
@@ -7,7 +7,7 @@ describe('LogSanitizer', () => {
     const sanitizer = new LogSanitizer()
 
     expect(
-      sanitizer.sanitize('Authorization: Bearer secret-token\nGITHUB_PAT=another-token\nGITHUB_TOKEN=fallback'),
-    ).toBe('Authorization: Bearer [REDACTED]\nGITHUB_PAT=[REDACTED]\nGITHUB_TOKEN=[REDACTED]')
+      sanitizer.sanitize('Authorization: Bearer secret-token\nGITHUB_PAT=another-token\nGITHUB_TOKEN=fallback\nGH_TOKEN=actions'),
+    ).toBe('Authorization: Bearer [REDACTED]\nGITHUB_PAT=[REDACTED]\nGITHUB_TOKEN=[REDACTED]\nGH_TOKEN=[REDACTED]')
   })
 })

--- a/cli/src/logging/LogSanitizer.ts
+++ b/cli/src/logging/LogSanitizer.ts
@@ -4,12 +4,16 @@ const secretPatterns: Array<{ pattern: RegExp; replacement: string }> = [
     replacement: 'Authorization: Bearer [REDACTED]',
   },
   {
-    pattern: /GITHUB_PAT=[^\r\n]*/gi,
+    pattern: /GITHUB_PAT=[^\s"']+/gi,
     replacement: 'GITHUB_PAT=[REDACTED]',
   },
   {
-    pattern: /GITHUB_TOKEN=[^\r\n]*/gi,
+    pattern: /GITHUB_TOKEN=[^\s"']+/gi,
     replacement: 'GITHUB_TOKEN=[REDACTED]',
+  },
+  {
+    pattern: /GH_TOKEN=[^\s"']+/gi,
+    replacement: 'GH_TOKEN=[REDACTED]',
   },
 ]
 

--- a/cli/src/runtime/ViteSiteDevServer.spec.ts
+++ b/cli/src/runtime/ViteSiteDevServer.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ViteSiteDevServer } from './ViteSiteDevServer'
 
 import type { AddressInfo } from 'node:net'
-import type { ViteDevServer } from 'vite'
+import type { InlineConfig, ViteDevServer } from 'vite'
 
 class StubPackagePaths {
   public getPackageRoot(): string {
@@ -80,6 +80,32 @@ describe('ViteSiteDevServer', () => {
       }),
     }))
     expect(runtimeWorkspace.cleanup).not.toHaveBeenCalled()
+  })
+
+  it('resolves port 0 to an explicit free port before starting Vite', async () => {
+    const createServer = vi.fn(async (config: InlineConfig) => createViteServerDouble({
+      address: {
+        address: '127.0.0.1',
+        family: 'IPv4',
+        port: Number(config.server?.port),
+      },
+    }))
+    const server = new ViteSiteDevServer(
+      new StubPackagePaths() as never,
+      new StubRuntimeWorkspace() as never,
+      createServer,
+    )
+
+    await expect(server.start({
+      getProjectRoot: () => '/project',
+    } as never, '127.0.0.1', 0)).resolves.toBeGreaterThan(0)
+
+    expect(createServer).toHaveBeenCalledWith(expect.objectContaining({
+      server: expect.objectContaining({
+        port: expect.any(Number),
+      }),
+    }))
+    expect(createServer.mock.calls[0]?.[0].server?.port).not.toBe(0)
   })
 
   it('closes the Vite server and cleans up the workspace when listen fails', async () => {

--- a/cli/src/runtime/ViteSiteDevServer.ts
+++ b/cli/src/runtime/ViteSiteDevServer.ts
@@ -1,3 +1,4 @@
+import { createServer as createNetServer } from 'node:net'
 import { resolve } from 'node:path'
 
 import autoprefixer from 'autoprefixer'
@@ -24,6 +25,7 @@ export class ViteSiteDevServer {
     const workspace = await this.runtimeWorkspace.prepare(paths, { liveContent: true })
 
     try {
+      const resolvedPort = port === 0 ? await this.findFreePort(host) : port
       const server = await this.createViteServer({
         appType: 'spa',
         root: workspace.appRoot,
@@ -42,7 +44,7 @@ export class ViteSiteDevServer {
         },
         server: {
           host,
-          port,
+          port: resolvedPort,
           strictPort: true,
           open: false,
           fs: {
@@ -75,6 +77,27 @@ export class ViteSiteDevServer {
 
     if (!address || typeof address === 'string') {
       throw new Error('Vite dev server did not expose a TCP address.')
+    }
+
+    return address.port
+  }
+
+  private async findFreePort(host: string): Promise<number> {
+    const server = createNetServer()
+
+    await new Promise<void>((resolvePromise, reject) => {
+      server.once('error', reject)
+      server.listen(0, host, () => resolvePromise())
+    })
+
+    const address = server.address()
+
+    await new Promise<void>((resolvePromise) => {
+      server.close(() => resolvePromise())
+    })
+
+    if (!address || typeof address === 'string') {
+      throw new Error('Unable to resolve a free TCP port.')
     }
 
     return address.port

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -13,6 +13,13 @@
     "skipLibCheck": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["src/**/*.ts", "../shared/src/**/*.ts"],
+  "include": [
+    "src/**/*.ts",
+    "e2e/**/*.ts",
+    "vitest.config.ts",
+    "vitest.e2e.config.ts",
+    "vitest.connectors-e2e.config.ts",
+    "../shared/src/**/*.ts"
+  ],
   "exclude": ["dist", "coverage", "../shared/src/**/*.spec.ts"]
 }

--- a/cli/vitest.connectors-e2e.config.ts
+++ b/cli/vitest.connectors-e2e.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['e2e/**/*.connectors.e2e.spec.ts'],
+    testTimeout: 180000,
+    hookTimeout: 180000,
+  },
+})

--- a/cli/vitest.e2e.config.ts
+++ b/cli/vitest.e2e.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['e2e/**/*.e2e.spec.ts'],
+    exclude: ['e2e/**/*.connectors.e2e.spec.ts'],
+    testTimeout: 120000,
+    hookTimeout: 120000,
+  },
+})

--- a/docs/cli/fetch.md
+++ b/docs/cli/fetch.md
@@ -33,6 +33,6 @@ It does not touch slide titles, roadmap content, spotlights, or CTAs.
 ## Requirements
 
 - `site.yaml` must define a data source (see [connectors](/connectors/))
-- For GitHub-backed fetches, set `GITHUB_PAT` in the project root `.env` file
+- For GitHub-backed fetches, set `GITHUB_PAT`, `GITHUB_TOKEN`, or `GH_TOKEN` in the shell environment or project root `.env` file
 - If you use interactive `init`, it can write that `.env` file for you
-- Without a PAT, GitHub fetches run in best-effort mode and may return less data
+- Without a token, GitHub fetches run in best-effort mode and may return less data

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -24,13 +24,18 @@ npx @slide-spec/cli init \
 | --- | --- | --- |
 | `[project-root]` (positional) | | Target directory. Defaults to current directory |
 | `--project-root` | | Alternative to the positional argument |
-| `--presentation-id` | non-interactive | Directory name under `presentations/` |
+| `--presentation-id` | non-interactive | Directory name under `presentations/`; use only letters, numbers, dots, underscores, and hyphens |
 | `--title` | non-interactive | Presentation title |
 | `--subtitle` | | Presentation subtitle |
 | `--from-date` | non-interactive | Reporting period start |
 | `--to-date` | | Reporting period end |
 | `--summary` | | Summary shown in the presentation list |
+| `--repository-url` | | Repository link written to `site.yaml` |
+| `--docs-url` | | Documentation link written to `site.yaml` |
+| `--website-url` | | Project website or community link written to `site.yaml` |
+| `--github-data-source-url` | | GitHub repository used by `fetch` to populate `generated.yaml` |
 | `--force` | | Overwrite existing files |
+| `--from-example [id]` | | Scaffold from a bundled example instead of creating a blank project |
 
 "non-interactive" means required only when running with flags instead of prompts.
 
@@ -51,3 +56,5 @@ content/
 If `site.yaml` or `index.yaml` already exist, they are updated rather than overwritten (unless `--force` is used).
 
 Scaffolded YAML files start with Slide Spec homepage and documentation links, then include `yaml-language-server` comments that point to the public Slide Spec JSON Schemas for editor validation and autocomplete.
+
+When `--github-data-source-url` is provided, `init` writes a GitHub connector entry to `site.yaml`. `fetch` can then populate `generated.yaml` for that project without additional connector configuration.

--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -25,9 +25,9 @@ Then run [`fetch`](/cli/fetch) to populate `generated.yaml`.
 
 ## Authentication
 
-A GitHub personal access token (PAT) is strongly recommended. Without one, requests hit public rate limits and return less data.
+A GitHub token is strongly recommended. Without one, requests hit public rate limits and return less data.
 
-Set `GITHUB_PAT` in the `.env` file at the project root you are fetching from. The interactive `init` flow can write that file for you if you enter a token during setup.
+Set `GITHUB_PAT`, `GITHUB_TOKEN`, or `GH_TOKEN` in your shell environment or in the `.env` file at the project root you are fetching from. Shell environment values take precedence over `.env` values. The interactive `init` flow can write `GITHUB_PAT` to `.env` for you if you enter a token during setup.
 
 Example:
 


### PR DESCRIPTION
## What

Adds e2e coverage for CLI.
While developing the e2e tests, a small handful of bugs were identified and remediated in the CLI, specifically around flags that were notated in the CLI help but not implemented completely in the CLI.

## Related issue

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x[ Documentation
- [x] Other (describe below)

e2e test coverage for CLI

## Breaking changes

<!-- Does this PR introduce a breaking change? Slide Spec follows semver - breaking changes must be clearly documented. -->

- [ ] Yes (describe below)
- [x] No

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes
