### PR TITLE
Allow icon definition in slide yaml

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,6 +29,7 @@
     "cyclonedx",
     "dast",
     "frontmatter",
+    "fontawesome",
     "lychee",
     "llms",
     "markdownlint",

--- a/app/src/components/slides/AgendaSlideView.vue
+++ b/app/src/components/slides/AgendaSlideView.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 
 import StandardSlideLayout from '../presentation/StandardSlideLayout.vue'
+import FaIcon from '../ui/FaIcon.vue'
 import SurfaceCard from '../ui/SurfaceCard.vue'
 
 import { getSlideLabel } from '../../content/slideLabels'
@@ -20,6 +21,7 @@ const agendaItems = computed(() =>
     .map((entry) => getSlideLabel(entry))
     .filter(Boolean) as string[],
 )
+const cardArrowFaIcon = computed(() => props.slide.content?.card_arrow_fa_icon ?? 'fa-chevron-right')
 </script>
 
 <template>
@@ -46,7 +48,7 @@ const agendaItems = computed(() =>
       >
         <div class="number-badge">{{ String(index + 1).padStart(2, '0') }}</div>
         <p class="card-text">{{ item }}</p>
-        <FontAwesomeIcon icon="chevron-right" class="card-arrow" />
+        <FaIcon :fa-icon="cardArrowFaIcon" class="card-arrow" />
       </SurfaceCard>
     </div>
   </StandardSlideLayout>

--- a/app/src/components/slides/CommunityHighlightsSlideView.vue
+++ b/app/src/components/slides/CommunityHighlightsSlideView.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 
 import StandardSlideLayout from '../presentation/StandardSlideLayout.vue'
+import FaIcon from '../ui/FaIcon.vue'
 import MetricStatCard from '../ui/MetricStatCard.vue'
 import SectionHeading from '../ui/SectionHeading.vue'
 import SurfaceCard from '../ui/SurfaceCard.vue'
@@ -20,8 +21,8 @@ const props = defineProps<{
   slideTotal: number
 }>()
 
-const mentionIcons = ['microphone-alt', 'rss', 'podcast']
-const statIcons = ['star', 'check-circle', 'code-branch', 'user-plus']
+const mentionFaIcons = ['fa-microphone-alt', 'fa-rss', 'fa-podcast']
+const statFaIcons = ['fa-star', 'fa-check-circle', 'fa-code-branch', 'fa-user-plus']
 
 function formatTrendLabel(
   previous: number,
@@ -51,7 +52,7 @@ function getTrendDirection(delta: number): 'up' | 'down' {
 const stats = computed(() =>
   props.slide.content.stat_keys.map((key, index) => ({
     ...props.generated.stats[key],
-    icon: statIcons[index],
+    faIcon: props.slide.content.stat_fa_icons?.[index] ?? statFaIcons[index] ?? 'fa-star',
     trendDirection: getTrendDirection(props.generated.stats[key].delta),
     trend: props.slide.content.show_deltas === false
       ? undefined
@@ -66,10 +67,15 @@ const stats = computed(() =>
 const mentionCards = computed(() =>
   props.slide.content.mentions.map((mention, index) => ({
     ...mention,
-    icon: mentionIcons[index] ?? 'rss',
+    faIcon: mention.fa_icon ?? mentionFaIcons[index] ?? 'fa-rss',
+    linkFaIcon: mention.link_fa_icon ?? 'fa-external-link-alt',
     isLinked: Boolean(mention.url),
   })),
 )
+const sectionHeadingFaIcon = computed(() => props.slide.content.section_heading_fa_icon ?? 'fa-bullhorn')
+const statsHeadingFaIcon = computed(() => props.slide.content.stats_heading_fa_icon ?? 'fa-chart-line')
+const trendUpFaIcon = computed(() => props.slide.content.trend_up_fa_icon ?? 'fa-arrow-up')
+const trendDownFaIcon = computed(() => props.slide.content.trend_down_fa_icon ?? 'fa-arrow-down')
 </script>
 
 <template>
@@ -84,7 +90,7 @@ const mentionCards = computed(() =>
       <div class="left-column">
         <SectionHeading
           v-if="slide.content.section_heading"
-          :icon="'bullhorn'"
+          :fa-icon="sectionHeadingFaIcon"
           :title="slide.content.section_heading"
         />
         <div class="mentions-list">
@@ -100,10 +106,10 @@ const mentionCards = computed(() =>
             radius="md"
             padding="20px"
           >
-            <div class="mention-type"><FontAwesomeIcon :icon="mention.icon" /> {{ mention.type }}</div>
+            <div class="mention-type"><FaIcon :fa-icon="mention.faIcon" /> {{ mention.type }}</div>
             <h3 class="mention-title">{{ mention.title }}</h3>
             <div v-if="mention.url && mention.url_label" class="mention-link">
-              <FontAwesomeIcon icon="external-link-alt" /> {{ mention.url_label }}
+              <FaIcon :fa-icon="mention.linkFaIcon" /> {{ mention.url_label }}
             </div>
           </SurfaceCard>
         </div>
@@ -112,7 +118,7 @@ const mentionCards = computed(() =>
       <div class="right-column">
         <SectionHeading
           v-if="slide.content.stats_heading"
-          :icon="'chart-line'"
+          :fa-icon="statsHeadingFaIcon"
           :title="slide.content.stats_heading"
         />
         <div class="stats-grid">
@@ -120,11 +126,13 @@ const mentionCards = computed(() =>
             v-for="stat in stats"
             :key="stat.label"
             class="stat-card"
-            :icon="stat.icon"
+            :fa-icon="stat.faIcon"
             :value="stat.current.toLocaleString()"
             :label="stat.label"
             :trend="stat.trend"
             :trend-direction="stat.trendDirection"
+            :trend-up-fa-icon="trendUpFaIcon"
+            :trend-down-fa-icon="trendDownFaIcon"
           />
         </div>
       </div>

--- a/app/src/components/slides/ContributorSpotlightSlideView.spec.ts
+++ b/app/src/components/slides/ContributorSpotlightSlideView.spec.ts
@@ -90,13 +90,9 @@ describe('ContributorSpotlightSlideView', () => {
     const names = wrapper.findAll('.contributor-name').map((node) => node.text())
     const handles = wrapper.findAll('.github-handle').map((node) => node.text())
     const links = wrapper.findAll('.github-handle').map((node) => node.attributes('href'))
-    const icons = wrapper
-      .findAllComponents({ name: 'FontAwesomeIcon' })
-      .map((node) => String(node.props('icon')))
-
     expect(names).toContain('mystery_contributor')
     expect(handles).toContain('@mystery_contributor')
     expect(links).toContain('https://github.com/mystery_contributor')
-    expect(icons).toContain('fa-user-secret')
+    expect(wrapper.find('.fa-user-secret').exists()).toBe(true)
   })
 })

--- a/app/src/components/slides/ContributorSpotlightSlideView.vue
+++ b/app/src/components/slides/ContributorSpotlightSlideView.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 
 import StandardSlideLayout from '../presentation/StandardSlideLayout.vue'
 import CalloutBanner from '../ui/CalloutBanner.vue'
+import FaIcon from '../ui/FaIcon.vue'
 import IconBadge from '../ui/IconBadge.vue'
 import SurfaceCard from '../ui/SurfaceCard.vue'
 
@@ -22,7 +23,7 @@ const props = defineProps<{
   slideTotal: number
 }>()
 
-const avatarIcons = ['user-astronaut', 'user-ninja', 'user-secret']
+const avatarFaIcons = ['fa-user-astronaut', 'fa-user-ninja', 'fa-user-secret']
 const contributors = computed(() =>
   props.slide.content.spotlight.map((entry, index) => {
     const contributor = props.generated.contributors.authors.find((author) => author.login === entry.login)
@@ -32,7 +33,7 @@ const contributors = computed(() =>
       name: contributor?.name ?? entry.login,
       handle: `@${entry.login}`,
       profileUrl: `https://github.com/${entry.login}`,
-      icon: avatarIcons[index] ?? 'fa-user-secret',
+      faIcon: entry.fa_icon ?? avatarFaIcons[index] ?? 'fa-user-secret',
     }
   }),
 )
@@ -48,6 +49,9 @@ const showBanner = computed(
     || Boolean(bannerContent.value.linkLabel)
     || Boolean(bannerContent.value.suffix),
 )
+const githubFaIcon = computed(() => props.slide.content.github_fa_icon ?? 'fa-github')
+const quoteFaIcon = computed(() => props.slide.content.quote_fa_icon ?? 'fa-quote-left')
+const bannerFaIcon = computed(() => props.slide.content.banner_fa_icon ?? 'fa-heart')
 </script>
 
 <template>
@@ -72,7 +76,7 @@ const showBanner = computed(
         padding="30px 24px"
       >
         <IconBadge
-          :icon="profile.icon"
+          :fa-icon="profile.faIcon"
           class="avatar-container"
           size="100px"
           icon-size="40px"
@@ -87,17 +91,17 @@ const showBanner = computed(
           target="_blank"
           rel="noreferrer"
         >
-          <FontAwesomeIcon :icon="['fab', 'github']" />
+          <FaIcon :fa-icon="githubFaIcon" />
           <span>{{ profile.handle }}</span>
         </a>
-        <FontAwesomeIcon icon="quote-left" class="quote-icon" />
+        <FaIcon :fa-icon="quoteFaIcon" class="quote-icon" />
         <p class="contribution-desc">{{ profile.summary }}</p>
       </SurfaceCard>
     </div>
 
     <CalloutBanner v-if="showBanner" class="thank-you-banner" variant="dashed" align="center">
       <p class="thank-you-text">
-        <FontAwesomeIcon icon="heart" class="thank-you-icon" />
+        <FaIcon :fa-icon="bannerFaIcon" class="thank-you-icon" />
         <template v-if="bannerContent.prefix">{{ bannerContent.prefix }} </template>
         <a
           v-if="bannerContent.linkLabel"

--- a/app/src/components/slides/HowToContributeSlideView.vue
+++ b/app/src/components/slides/HowToContributeSlideView.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 
 import StandardSlideLayout from '../presentation/StandardSlideLayout.vue'
 import CalloutBanner from '../ui/CalloutBanner.vue'
+import FaIcon from '../ui/FaIcon.vue'
 import FooterActionLink from '../ui/FooterActionLink.vue'
 import IconBadge from '../ui/IconBadge.vue'
 import SurfaceCard from '../ui/SurfaceCard.vue'
@@ -17,10 +18,12 @@ const props = defineProps<{
   slideTotal: number
 }>()
 
-const icons = ['bug', 'code-branch', 'book', 'bullhorn']
-const trailingIcons = ['arrow-right', 'arrow-right', 'arrow-right', 'star']
+const defaultCardFaIcons = ['fa-bug', 'fa-code-branch', 'fa-book', 'fa-bullhorn']
+const defaultLinkFaIcons = ['fa-arrow-right', 'fa-arrow-right', 'fa-arrow-right', 'fa-star']
 const repositoryLink = computed(() => props.site.links.repository)
 const showFooterCta = computed(() => Boolean(props.slide.content.footer_text?.trim()) || Boolean(repositoryLink.value))
+const footerFaIcon = computed(() => props.slide.content.footer_fa_icon ?? 'fa-github')
+const footerLinkFaIcon = computed(() => props.slide.content.footer_link_fa_icon ?? 'fa-code')
 </script>
 
 <template>
@@ -48,12 +51,17 @@ const showFooterCta = computed(() => Boolean(props.slide.content.footer_text?.tr
         min-height="184px"
         max-height="220px"
       >
-        <IconBadge :icon="icons[index]" shape="rounded" class="icon-wrapper" icon-size="28px" />
+        <IconBadge
+          :fa-icon="card.fa_icon ?? defaultCardFaIcons[index] ?? 'fa-star'"
+          shape="rounded"
+          class="icon-wrapper"
+          icon-size="28px"
+        />
         <div class="card-content">
           <h2 class="card-title">{{ card.title }}</h2>
           <p class="card-text">{{ card.description }}</p>
           <a class="card-link" :href="card.url" target="_blank" rel="noreferrer">
-            {{ card.url_label }} <FontAwesomeIcon :icon="trailingIcons[index]" />
+            {{ card.url_label }} <FaIcon :fa-icon="card.link_fa_icon ?? defaultLinkFaIcons[index] ?? 'fa-arrow-right'" />
           </a>
         </div>
       </SurfaceCard>
@@ -61,11 +69,11 @@ const showFooterCta = computed(() => Boolean(props.slide.content.footer_text?.tr
 
     <CalloutBanner v-if="showFooterCta" class="footer-cta">
       <div class="repo-info">
-        <FontAwesomeIcon :icon="['fab', 'github']" class="text-xl mr-3" />
+        <FaIcon :fa-icon="footerFaIcon" class="text-xl mr-3" />
         <p v-if="slide.content.footer_text">{{ slide.content.footer_text }}</p>
       </div>
       <template v-if="repositoryLink" #action>
-        <FooterActionLink :href="repositoryLink.url" icon="code" :label="repositoryLink.label" />
+        <FooterActionLink :href="repositoryLink.url" :fa-icon="footerLinkFaIcon" :label="repositoryLink.label" />
       </template>
     </CalloutBanner>
   </StandardSlideLayout>

--- a/app/src/components/slides/RecentUpdatesSlideView.spec.ts
+++ b/app/src/components/slides/RecentUpdatesSlideView.spec.ts
@@ -42,4 +42,29 @@ describe('RecentUpdatesSlideView', () => {
 
     expect(wrapper.find('.page-title').exists()).toBe(false)
   })
+
+  it('uses configured, ordered default, and overflow fallback icons', () => {
+    const wrapper = mount(RecentUpdatesSlideView, {
+      props: {
+        presentation: record.presentation,
+        slide: {
+          ...slide,
+          content: {
+            sections: [
+              { title: 'Custom', fa_icon: 'fa-code', bullets: ['Custom icon'] },
+              { title: 'Default', bullets: ['Ordered default icon'] },
+              { title: 'Third', bullets: ['Third ordered default'] },
+              { title: 'Overflow', bullets: ['Overflow fallback icon'] },
+            ],
+          },
+        },
+        slideNumber: 3,
+        slideTotal: 12,
+      },
+    })
+
+    expect(wrapper.find('.fa-code').exists()).toBe(true)
+    expect(wrapper.find('.fa-users').exists()).toBe(true)
+    expect(wrapper.findAll('.fa-star')).toHaveLength(2)
+  })
 })

--- a/app/src/components/slides/RecentUpdatesSlideView.vue
+++ b/app/src/components/slides/RecentUpdatesSlideView.vue
@@ -12,7 +12,7 @@ defineProps<{
   slideTotal: number
 }>()
 
-const icons = ['wrench', 'star', 'users']
+const defaultSectionFaIcons = ['fa-wrench', 'fa-star', 'fa-users']
 </script>
 
 <template>
@@ -34,7 +34,7 @@ const icons = ['wrench', 'star', 'users']
         radius="md"
         padding="30px"
       >
-        <IconBadge :icon="icons[index]" class="icon-container" />
+        <IconBadge :fa-icon="section.fa_icon ?? defaultSectionFaIcons[index] ?? 'fa-star'" class="icon-container" />
         <h2 class="card-title">{{ section.title }}</h2>
         <ul class="bullet-list">
           <li v-for="bullet in section.bullets" :key="bullet" class="bullet-item">{{ bullet }}</li>

--- a/app/src/components/slides/ReleasesSlideView.spec.ts
+++ b/app/src/components/slides/ReleasesSlideView.spec.ts
@@ -97,8 +97,8 @@ describe('ReleasesSlideView', () => {
     expect(releaseCards[1]?.attributes('href')).toBe(
       'https://github.com/example-org/aurora-notes/releases/tag/v9.8.0',
     )
-    expect(releaseComponents[0]?.props('labelIcon')).toBe('tag')
-    expect(releaseComponents[1]?.props('labelIcon')).toBe('code-branch')
+    expect(releaseComponents[0]?.props('labelFaIcon')).toBe('fa-tag')
+    expect(releaseComponents[1]?.props('labelFaIcon')).toBe('fa-code-branch')
     expect(releaseComponents[0]?.props('badgeLabel')).toBe(slide.content.latest_badge_label)
     expect(releaseComponents[1]?.props('badgeLabel')).toBeUndefined()
     expect(wrapper.text()).toContain('First bullet')

--- a/app/src/components/slides/ReleasesSlideView.vue
+++ b/app/src/components/slides/ReleasesSlideView.vue
@@ -32,6 +32,9 @@ const releases = computed(() =>
 )
 const releasesUrl = computed(() => `${props.site.links.repository.url}/releases`)
 const hasReleases = computed(() => releases.value.length > 0)
+const latestReleaseFaIcon = computed(() => props.slide.content.latest_release_fa_icon ?? 'fa-tag')
+const releaseFaIcon = computed(() => props.slide.content.release_fa_icon ?? 'fa-code-branch')
+const footerLinkFaIcon = computed(() => props.slide.content.footer_link_fa_icon ?? 'fa-github')
 </script>
 
 <template>
@@ -51,7 +54,7 @@ const hasReleases = computed(() => releases.value.length > 0)
           class="release-card"
           :href="release.githubUrl"
           :label="release.version"
-          :label-icon="index === 0 ? 'tag' : 'code-branch'"
+          :label-fa-icon="index === 0 ? latestReleaseFaIcon : releaseFaIcon"
           :date="formatter.format(new Date(release.published_at))"
           :items="release.summary_bullets"
           :highlighted="index === 0"
@@ -74,7 +77,7 @@ const hasReleases = computed(() => releases.value.length > 0)
         <FooterActionLink
           class="github-link"
           :href="releasesUrl"
-          :icon="['fab', 'github']"
+          :fa-icon="footerLinkFaIcon"
           :label="slide.content.footer_link_label"
         />
       </div>

--- a/app/src/components/slides/RoadmapSlideView.vue
+++ b/app/src/components/slides/RoadmapSlideView.vue
@@ -46,6 +46,10 @@ const timelineStages = computed(() =>
 )
 const activeStage = computed(() => stages.value?.[props.slide.content.stage])
 const roadmapLabels = computed(() => resolveRoadmapLabels(props.slide.content))
+const itemFaIcon = computed(() => props.slide.content.item_fa_icon ?? 'fa-chevron-right')
+const focusAreasFaIcon = computed(() => props.slide.content.focus_areas_fa_icon ?? 'fa-bullseye')
+const themeFaIcon = computed(() => props.slide.content.theme_fa_icon ?? 'fa-chevron-right')
+const footerLinkFaIcon = computed(() => props.slide.content.footer_link_fa_icon ?? 'fa-github')
 </script>
 
 <template>
@@ -71,13 +75,14 @@ const roadmapLabels = computed(() => resolveRoadmapLabels(props.slide.content))
         <section class="detail-card detail-card--primary">
           <p v-if="activeStage?.label" class="card-eyebrow">{{ activeStage.label }}</p>
           <h2 v-if="roadmapLabels.deliverables" class="card-title">{{ roadmapLabels.deliverables }}</h2>
-          <ContentList :items="slide.content.items" marker="icon" icon="chevron-right" class="detail-list" />
+          <ContentList :items="slide.content.items" marker="icon" :fa-icon="itemFaIcon" class="detail-list" />
         </section>
 
         <section class="detail-card detail-card--secondary">
-          <SectionHeading v-if="roadmapLabels.focusAreas" icon="bullseye" :title="roadmapLabels.focusAreas" />
+          <SectionHeading v-if="roadmapLabels.focusAreas" :fa-icon="focusAreasFaIcon" :title="roadmapLabels.focusAreas" />
           <KeyValueRows
             :rows="slide.content.themes.map((theme) => ({ key: theme.category, value: theme.target }))"
+            :value-fa-icon="themeFaIcon"
             class="themes-grid"
           />
         </section>
@@ -87,7 +92,7 @@ const roadmapLabels = computed(() => resolveRoadmapLabels(props.slide.content))
         v-if="roadmapLabels.footerLink"
         class="footer-link"
         :href="site.links.repository.url"
-        :icon="['fab', 'github']"
+        :fa-icon="footerLinkFaIcon"
         :label="roadmapLabels.footerLink"
       />
     </div>

--- a/app/src/components/slides/ThankYouSlideView.spec.ts
+++ b/app/src/components/slides/ThankYouSlideView.spec.ts
@@ -73,4 +73,27 @@ describe('ThankYouSlideView', () => {
 
     expect(wrapper.find('.presentation-mark').exists()).toBe(false)
   })
+
+  it('falls back to default resource icons when no icon overrides are authored', () => {
+    const wrapper = mount(ThankYouSlideView, {
+      props: {
+        presentation: record.presentation,
+        generated: record.generated,
+        site,
+        slide: {
+          ...slide,
+          content: {
+            ...slide.content,
+            repository_fa_icon: undefined,
+            docs_fa_icon: undefined,
+            community_fa_icon: undefined,
+          },
+        },
+      },
+    })
+
+    expect(wrapper.find('.fa-github').exists()).toBe(true)
+    expect(wrapper.find('.fa-book').exists()).toBe(true)
+    expect(wrapper.find('.fa-shield-alt').exists()).toBe(true)
+  })
 })

--- a/app/src/components/slides/ThankYouSlideView.vue
+++ b/app/src/components/slides/ThankYouSlideView.vue
@@ -25,6 +25,9 @@ const props = defineProps<{
 const markLabel = computed(() => resolvePresentationChromeLabel(props.site))
 const mascotUrl = computed(() => assetResolver.resolve(props.site.mascot?.url))
 const mascotAlt = computed(() => props.site.mascot?.alt?.trim() || undefined)
+const repositoryFaIcon = computed(() => props.slide.content.repository_fa_icon ?? 'fa-github')
+const docsFaIcon = computed(() => props.slide.content.docs_fa_icon ?? 'fa-book')
+const communityFaIcon = computed(() => props.slide.content.community_fa_icon ?? 'fa-shield-alt')
 </script>
 
 <template>
@@ -55,19 +58,19 @@ const mascotAlt = computed(() => props.site.mascot?.alt?.trim() || undefined)
       <div class="actions">
         <ResourcePillLink
           :href="site.links.repository.url"
-          :icon="['fab', 'github']"
+          :fa-icon="repositoryFaIcon"
           :eyebrow="site.links.repository.eyebrow"
           :title="site.links.repository.label"
         />
         <ResourcePillLink
           :href="site.links.docs.url"
-          icon="book"
+          :fa-icon="docsFaIcon"
           :eyebrow="site.links.docs.eyebrow"
           :title="site.links.docs.label"
         />
         <ResourcePillLink
           :href="site.links.community.url"
-          icon="shield-alt"
+          :fa-icon="communityFaIcon"
           :eyebrow="site.links.community.eyebrow"
           :title="site.links.community.label"
         />

--- a/app/src/components/ui/ContentList.spec.ts
+++ b/app/src/components/ui/ContentList.spec.ts
@@ -9,7 +9,7 @@ describe('ContentList', () => {
       props: {
         items: ['First', 'Second'],
         marker: 'icon',
-        icon: 'chevron-right',
+        faIcon: 'fa-chevron-right',
       },
     })
 

--- a/app/src/components/ui/ContentList.vue
+++ b/app/src/components/ui/ContentList.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
+import FaIcon from './FaIcon.vue'
+
 const props = withDefaults(
   defineProps<{
     items: string[]
     marker?: 'icon' | 'bullet'
-    icon?: string | [string, string]
+    faIcon?: string
     markerColor?: string
     gap?: string
     itemPaddingLeft?: string
   }>(),
   {
     marker: 'bullet',
-    icon: 'chevron-right',
+    faIcon: 'fa-chevron-right',
     markerColor: '#e8341c',
     gap: '0.9rem',
     itemPaddingLeft: '20px',
@@ -28,7 +30,7 @@ const props = withDefaults(
     }"
   >
     <li v-for="item in items" :key="item" class="content-list__item" :class="`content-list__item--${marker}`">
-      <FontAwesomeIcon v-if="marker === 'icon'" :icon="icon" class="content-list__icon" />
+      <FaIcon v-if="marker === 'icon'" :fa-icon="faIcon" class="content-list__icon" />
       <span>{{ item }}</span>
     </li>
   </ul>

--- a/app/src/components/ui/FaIcon.spec.ts
+++ b/app/src/components/ui/FaIcon.spec.ts
@@ -1,0 +1,28 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import FaIcon from './FaIcon.vue'
+
+describe('FaIcon', () => {
+  it('normalizes supported icon classes', () => {
+    const wrapper = mount(FaIcon, {
+      props: {
+        faIcon: 'fa-github',
+      },
+    })
+
+    expect(wrapper.classes()).toContain('fa-brands')
+    expect(wrapper.classes()).toContain('fa-github')
+  })
+
+  it('falls back when an unchecked icon value reaches rendering', () => {
+    const wrapper = mount(FaIcon, {
+      props: {
+        faIcon: 'fa-nope',
+      },
+    })
+
+    expect(wrapper.classes()).toContain('fa-solid')
+    expect(wrapper.classes()).toContain('fa-star')
+  })
+})

--- a/app/src/components/ui/FaIcon.vue
+++ b/app/src/components/ui/FaIcon.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { normalizeFontAwesomeIcon } from '../../../../shared/src/fontawesome'
+
+const props = defineProps<{
+  faIcon: string
+}>()
+
+const iconClass = computed(() => normalizeFontAwesomeIcon(props.faIcon) ?? 'fa-solid fa-star')
+</script>
+
+<template>
+  <i :class="iconClass" aria-hidden="true"></i>
+</template>

--- a/app/src/components/ui/FooterActionLink.spec.ts
+++ b/app/src/components/ui/FooterActionLink.spec.ts
@@ -8,7 +8,7 @@ describe('FooterActionLink', () => {
     const wrapper = mount(FooterActionLink, {
       props: {
         href: 'https://example.com',
-        icon: ['fab', 'github'],
+        faIcon: 'fa-github',
         label: 'Open on GitHub',
       },
     })
@@ -22,7 +22,7 @@ describe('FooterActionLink', () => {
     const wrapper = mount(FooterActionLink, {
       props: {
         href: 'https://example.com',
-        icon: 'code',
+        faIcon: 'fa-code',
         label: 'Source',
         align: 'start',
       },

--- a/app/src/components/ui/FooterActionLink.vue
+++ b/app/src/components/ui/FooterActionLink.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import FaIcon from './FaIcon.vue'
+
 const props = withDefaults(
   defineProps<{
     href: string
-    icon: string | [string, string]
+    faIcon: string
     label: string
     align?: 'start' | 'end' | 'center'
   }>(),
@@ -20,7 +22,7 @@ const props = withDefaults(
     target="_blank"
     rel="noreferrer"
   >
-    <FontAwesomeIcon :icon="icon" />
+    <FaIcon :fa-icon="faIcon" />
     <span>{{ label }}</span>
   </a>
 </template>

--- a/app/src/components/ui/IconBadge.spec.ts
+++ b/app/src/components/ui/IconBadge.spec.ts
@@ -7,7 +7,7 @@ describe('IconBadge', () => {
   it('renders a circular icon badge with defaults', () => {
     const wrapper = mount(IconBadge, {
       props: {
-        icon: 'star',
+        faIcon: 'fa-star',
       },
     })
 
@@ -18,7 +18,7 @@ describe('IconBadge', () => {
   it('supports rounded badges and custom visual values', () => {
     const wrapper = mount(IconBadge, {
       props: {
-        icon: ['fab', 'github'],
+        faIcon: 'fa-github',
         shape: 'rounded',
         size: '100px',
         iconSize: '40px',

--- a/app/src/components/ui/IconBadge.vue
+++ b/app/src/components/ui/IconBadge.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
+import FaIcon from './FaIcon.vue'
+
 defineOptions({
   inheritAttrs: false,
 })
 
 const props = withDefaults(
   defineProps<{
-    icon: string | [string, string]
+    faIcon: string
     shape?: 'circle' | 'rounded'
     size?: string
     iconSize?: string
@@ -36,7 +38,7 @@ const styleVars = computed(() => ({
 
 <template>
   <div class="icon-badge" :class="`icon-badge--${shape}`" :style="styleVars" v-bind="$attrs">
-    <FontAwesomeIcon :icon="icon" class="icon-badge__icon" />
+    <FaIcon :fa-icon="faIcon" class="icon-badge__icon" />
   </div>
 </template>
 

--- a/app/src/components/ui/KeyValueRows.vue
+++ b/app/src/components/ui/KeyValueRows.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import FaIcon from './FaIcon.vue'
+
 export interface KeyValueRow {
   key: string
   value: string
@@ -7,10 +9,10 @@ export interface KeyValueRow {
 withDefaults(
   defineProps<{
     rows: KeyValueRow[]
-    valueIcon?: string | [string, string]
+    valueFaIcon?: string
   }>(),
   {
-    valueIcon: 'chevron-right',
+    valueFaIcon: 'fa-chevron-right',
   },
 )
 </script>
@@ -20,7 +22,7 @@ withDefaults(
     <div v-for="row in rows" :key="row.key" class="key-value-rows__row">
       <div class="key-value-rows__key">{{ row.key }}</div>
       <div class="key-value-rows__value">
-        <FontAwesomeIcon :icon="valueIcon" class="key-value-rows__icon" />
+        <FaIcon :fa-icon="valueFaIcon" class="key-value-rows__icon" />
         <p>{{ row.value }}</p>
       </div>
     </div>

--- a/app/src/components/ui/MetricStatCard.spec.ts
+++ b/app/src/components/ui/MetricStatCard.spec.ts
@@ -7,7 +7,7 @@ describe('MetricStatCard', () => {
   it('renders value, label, and trend', () => {
     const wrapper = mount(MetricStatCard, {
       props: {
-        icon: 'star',
+        faIcon: 'fa-star',
         value: '1,234',
         label: 'GitHub Stars',
         trend: '+12% vs last Q',
@@ -22,7 +22,7 @@ describe('MetricStatCard', () => {
   it('renders a down trend with the down arrow class when requested', () => {
     const wrapper = mount(MetricStatCard, {
       props: {
-        icon: 'star',
+        faIcon: 'fa-star',
         value: '4',
         label: 'New contributors',
         trend: '-20% vs last presentation',
@@ -38,7 +38,7 @@ describe('MetricStatCard', () => {
   it('omits trend when not provided', () => {
     const wrapper = mount(MetricStatCard, {
       props: {
-        icon: 'star',
+        faIcon: 'fa-star',
         value: '7',
         label: 'Open issues',
       },

--- a/app/src/components/ui/MetricStatCard.vue
+++ b/app/src/components/ui/MetricStatCard.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
+import FaIcon from './FaIcon.vue'
 import IconBadge from './IconBadge.vue'
 import SurfaceCard from './SurfaceCard.vue'
 
 defineProps<{
-  icon: string | [string, string]
+  faIcon: string
   value: string
   label: string
   trend?: string
   trendDirection?: 'up' | 'down'
+  trendUpFaIcon?: string
+  trendDownFaIcon?: string
 }>()
 </script>
 
@@ -19,17 +22,17 @@ defineProps<{
     radius="md"
     padding="25px 20px"
   >
-    <IconBadge :icon="icon" class="metric-stat-card__icon" size="48px" icon-size="20px" />
+    <IconBadge :fa-icon="faIcon" class="metric-stat-card__icon" size="48px" icon-size="20px" />
     <p class="metric-stat-card__value">{{ value }}</p>
     <p class="metric-stat-card__label">{{ label }}</p>
     <div
       v-if="trend"
       class="metric-stat-card__trend"
       :class="{
-        'metric-stat-card__trend--down': trendDirection === 'down',
+      'metric-stat-card__trend--down': trendDirection === 'down',
       }"
     >
-      <FontAwesomeIcon :icon="trendDirection === 'down' ? 'arrow-down' : 'arrow-up'" />
+      <FaIcon :fa-icon="trendDirection === 'down' ? trendDownFaIcon ?? 'fa-arrow-down' : trendUpFaIcon ?? 'fa-arrow-up'" />
       <span>{{ trend }}</span>
     </div>
   </SurfaceCard>

--- a/app/src/components/ui/ProjectBadgePill.spec.ts
+++ b/app/src/components/ui/ProjectBadgePill.spec.ts
@@ -9,7 +9,7 @@ describe('ProjectBadgePill', () => {
       props: {
         badge: {
           label: 'OWASP Lab Project',
-          iconClass: 'fas fa-flask',
+          iconClass: 'fa-solid fa-flask',
           iconPosition: 'before',
         },
       },
@@ -24,7 +24,7 @@ describe('ProjectBadgePill', () => {
       props: {
         badge: {
           label: 'Badge Text',
-          iconClass: 'fas fa-star',
+          iconClass: 'fa-solid fa-star',
           iconPosition: 'after',
         },
       },

--- a/app/src/components/ui/ResourcePillLink.spec.ts
+++ b/app/src/components/ui/ResourcePillLink.spec.ts
@@ -8,7 +8,7 @@ describe('ResourcePillLink', () => {
     const wrapper = mount(ResourcePillLink, {
       props: {
         href: 'https://example.com',
-        icon: ['fab', 'github'],
+        faIcon: 'fa-github',
         eyebrow: 'Source Code',
         title: 'GitHub Repo',
       },
@@ -23,7 +23,7 @@ describe('ResourcePillLink', () => {
     const wrapper = mount(ResourcePillLink, {
       props: {
         href: 'https://example.com',
-        icon: 'book',
+        faIcon: 'fa-book',
         title: 'Read the Docs',
       },
     })

--- a/app/src/components/ui/ResourcePillLink.vue
+++ b/app/src/components/ui/ResourcePillLink.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import FaIcon from './FaIcon.vue'
+
 defineProps<{
   href: string
-  icon: string | [string, string]
+  faIcon: string
   title: string
   eyebrow?: string
 }>()
@@ -9,7 +11,7 @@ defineProps<{
 
 <template>
   <a class="resource-pill-link" :href="href" target="_blank" rel="noreferrer">
-    <FontAwesomeIcon :icon="icon" class="resource-pill-link__icon" />
+    <FaIcon :fa-icon="faIcon" class="resource-pill-link__icon" />
     <div class="resource-pill-link__copy">
       <span v-if="eyebrow" class="resource-pill-link__eyebrow">{{ eyebrow }}</span>
       <span class="resource-pill-link__title">{{ title }}</span>

--- a/app/src/components/ui/SectionHeading.spec.ts
+++ b/app/src/components/ui/SectionHeading.spec.ts
@@ -8,7 +8,7 @@ describe('SectionHeading', () => {
     const wrapper = mount(SectionHeading, {
       props: {
         title: 'Community Activity',
-        icon: 'bullhorn',
+        faIcon: 'fa-bullhorn',
       },
     })
 

--- a/app/src/components/ui/SectionHeading.vue
+++ b/app/src/components/ui/SectionHeading.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
+import FaIcon from './FaIcon.vue'
+
 defineProps<{
   title: string
-  icon: string | [string, string]
+  faIcon: string
 }>()
 </script>
 
 <template>
   <div class="section-heading">
     <h2 class="section-heading__title">
-      <FontAwesomeIcon :icon="icon" class="section-heading__icon" />
+      <FaIcon :fa-icon="faIcon" class="section-heading__icon" />
       <span>{{ title }}</span>
     </h2>
   </div>

--- a/app/src/components/ui/TimelineEventCard.spec.ts
+++ b/app/src/components/ui/TimelineEventCard.spec.ts
@@ -9,7 +9,7 @@ describe('TimelineEventCard', () => {
       props: {
         href: 'https://example.com/release',
         label: 'v1.0.0',
-        labelIcon: 'tag',
+        labelFaIcon: 'fa-tag',
         date: 'January 1, 2026',
         items: ['One', 'Two'],
         highlighted: true,
@@ -29,7 +29,7 @@ describe('TimelineEventCard', () => {
       props: {
         href: 'https://example.com/release',
         label: 'v0.9.0',
-        labelIcon: ['fab', 'github'],
+        labelFaIcon: 'fa-github',
         date: 'December 1, 2025',
         items: ['Only'],
       },

--- a/app/src/components/ui/TimelineEventCard.vue
+++ b/app/src/components/ui/TimelineEventCard.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import ContentList from './ContentList.vue'
+import FaIcon from './FaIcon.vue'
 import SurfaceCard from './SurfaceCard.vue'
 
 defineProps<{
   href: string
   label: string
-  labelIcon: string | [string, string]
+  labelFaIcon: string
   date: string
   items: string[]
   highlighted?: boolean
@@ -31,7 +32,7 @@ defineProps<{
     <div class="timeline-event-card__header">
       <div class="timeline-event-card__label-group">
         <span class="timeline-event-card__label">
-          <FontAwesomeIcon :icon="labelIcon" />
+          <FaIcon :fa-icon="labelFaIcon" class="timeline-event-card__label-icon" />
           {{ label }}
         </span>
         <span v-if="badgeLabel" class="timeline-event-card__badge">{{ badgeLabel }}</span>
@@ -99,7 +100,7 @@ defineProps<{
   font: 700 18px/1 var(--font-mono);
 }
 
-.timeline-event-card__label :deep(svg) {
+.timeline-event-card__label-icon {
   margin-right: 10px;
   color: #e8341c;
   font-size: 16px;

--- a/app/src/content/ContentValidator.spec.ts
+++ b/app/src/content/ContentValidator.spec.ts
@@ -483,7 +483,21 @@ describe('ContentValidator', () => {
     expect(() => validator.validatePresentationDocument(document)).not.toThrow()
   })
 
-  it('rejects agenda slides with non-empty content', () => {
+  it('accepts agenda slides with supported icon content', () => {
+    const document = createValidPresentationDocument()
+    document.presentation.slides = [
+      {
+        template: 'agenda',
+        enabled: true,
+        title: 'Agenda',
+        content: { card_arrow_fa_icon: 'fa-arrow-right' },
+      } as never,
+    ]
+
+    expect(() => validator.validatePresentationDocument(document)).not.toThrow()
+  })
+
+  it('rejects agenda slides with unsupported content', () => {
     const document = createValidPresentationDocument()
     document.presentation.slides = [
       {
@@ -495,7 +509,7 @@ describe('ContentValidator', () => {
     ]
 
     expect(() => validator.validatePresentationDocument(document)).toThrow(
-      'presentation document.presentation.slides[0].content must be omitted or an empty object for agenda slides.',
+      'presentation document.presentation.slides[0].content.unused is not allowed.',
     )
   })
 

--- a/app/src/content/projectBadge.spec.ts
+++ b/app/src/content/projectBadge.spec.ts
@@ -19,7 +19,7 @@ describe('getProjectBadgeDisplay', () => {
       }),
     ).toEqual({
       label: 'Demo Lab Project',
-      iconClass: 'fas fa-flask',
+      iconClass: 'fa-solid fa-flask',
       iconPosition: 'before',
     })
   })
@@ -38,7 +38,7 @@ describe('getProjectBadgeDisplay', () => {
       }),
     ).toEqual({
       label: undefined,
-      iconClass: 'fab fa-github',
+      iconClass: 'fa-brands fa-github',
       iconPosition: 'before',
     })
   })
@@ -75,7 +75,7 @@ describe('getProjectBadgeDisplay', () => {
         title: 'Aurora Notes Quarterly Updates',
         project_badge: {
           label: 'Custom Badge',
-          fa_icon: 'fa-flag',
+          fa_icon: 'fa-star',
           icon_position: 'after',
         },
         home_intro: 'Quarterly community updates',
@@ -85,7 +85,7 @@ describe('getProjectBadgeDisplay', () => {
       }),
     ).toEqual({
       label: 'Custom Badge',
-      iconClass: 'fas fa-flag',
+      iconClass: 'fa-solid fa-star',
       iconPosition: 'after',
     })
   })

--- a/app/src/content/projectBadge.ts
+++ b/app/src/content/projectBadge.ts
@@ -1,4 +1,5 @@
 import type { SiteContent } from '../types/content'
+import { normalizeFontAwesomeIcon } from '../../../shared/src/fontawesome'
 
 export interface ProjectBadgeDisplay {
   label?: string
@@ -11,13 +12,7 @@ const normalizeIconClass = (faIcon?: string): string | undefined => {
     return undefined
   }
 
-  const trimmed = faIcon.trim()
-
-  if (trimmed.includes(' ')) {
-    return trimmed
-  }
-
-  return `fas ${trimmed}`
+  return normalizeFontAwesomeIcon(faIcon)
 }
 
 export const getProjectBadgeDisplay = (site: SiteContent): ProjectBadgeDisplay | null => {

--- a/app/src/types/content.ts
+++ b/app/src/types/content.ts
@@ -158,7 +158,9 @@ export interface SectionTitleSlideContent {
   image_alt?: string
 }
 
-export type AgendaSlideContent = Record<string, never>
+export interface AgendaSlideContent {
+  card_arrow_fa_icon?: string
+}
 
 export interface SectionListGridSlideContent {
   sections: ContentSection[]
@@ -169,6 +171,9 @@ export interface TimelineSlideContent {
   footer_link_label?: string
   empty_state_title?: string
   empty_state_message?: string
+  latest_release_fa_icon?: string
+  release_fa_icon?: string
+  footer_link_fa_icon?: string
   featured_release_ids: string[]
 }
 
@@ -177,6 +182,10 @@ export interface ProgressTimelineSlideContent {
   deliverables_heading?: string
   focus_areas_heading?: string
   footer_link_label?: string
+  item_fa_icon?: string
+  focus_areas_fa_icon?: string
+  theme_fa_icon?: string
+  footer_link_fa_icon?: string
   stages: Record<RoadmapStageStatus, RoadmapStageSummary>
   items: string[]
   themes: RoadmapTheme[]
@@ -186,6 +195,9 @@ export interface PeopleSlideContent {
   banner_prefix?: string
   contributors_link_label?: string
   banner_suffix?: string
+  github_fa_icon?: string
+  quote_fa_icon?: string
+  banner_fa_icon?: string
   spotlight: SpotlightEntry[]
 }
 
@@ -194,12 +206,19 @@ export interface MetricsAndLinksSlideContent {
   stats_heading?: string
   show_deltas?: boolean
   trend_suffix?: string
+  section_heading_fa_icon?: string
+  stats_heading_fa_icon?: string
+  stat_fa_icons?: string[]
+  trend_up_fa_icon?: string
+  trend_down_fa_icon?: string
   stat_keys: string[]
   mentions: CommunityMention[]
 }
 
 export interface ActionCardsSlideContent {
   footer_text?: string
+  footer_fa_icon?: string
+  footer_link_fa_icon?: string
   cards: ContributionCard[]
 }
 
@@ -219,6 +238,9 @@ export interface ClosingSlideContent {
   heading: string
   message: string
   quote?: string
+  repository_fa_icon?: string
+  docs_fa_icon?: string
+  community_fa_icon?: string
 }
 
 export type TitleSlide = SlideBase<'hero', HeroSlideContent>
@@ -269,6 +291,7 @@ export interface PresentationContent {
 export interface ContentSection {
   title: string
   bullets: string[]
+  fa_icon?: string
 }
 
 export type RoadmapStageStatus = 'completed' | 'in-progress' | 'planned' | 'future'
@@ -286,6 +309,7 @@ export interface RoadmapStageSummary {
 export interface SpotlightEntry {
   login: string
   summary: string
+  fa_icon?: string
 }
 
 export interface CommunityMention {
@@ -293,6 +317,8 @@ export interface CommunityMention {
   title: string
   url_label?: string
   url?: string
+  fa_icon?: string
+  link_fa_icon?: string
 }
 
 export interface ContributionCard {
@@ -300,6 +326,8 @@ export interface ContributionCard {
   description: string
   url_label: string
   url: string
+  fa_icon?: string
+  link_fa_icon?: string
 }
 
 export interface PresentationRecord {

--- a/cli/examples-synced/open-source-update/presentations/2026-q1-update/presentation.yaml
+++ b/cli/examples-synced/open-source-update/presentations/2026-q1-update/presentation.yaml
@@ -20,6 +20,8 @@ presentation:
       enabled: true
       title: Agenda
       subtitle: What this update covers
+      content:
+        card_arrow_fa_icon: fa-arrow-right
     - template: section-list-grid
       enabled: true
       title: What shipped
@@ -27,16 +29,19 @@ presentation:
       content:
         sections:
           - title: Plugin system
+            fa_icon: fa-code-branch
             bullets:
               - Local plugins resolve from the project directory
               - Registry plugins install from the public catalog
               - Lifecycle hooks for init, build, and deploy phases
           - title: Error messages
+            fa_icon: fa-bug
             bullets:
               - Structured output with error codes and fix suggestions
               - Links to relevant documentation in every error
               - Machine-readable JSON output for CI pipelines
           - title: Shell completions
+            fa_icon: fa-wrench
             bullets:
               - Auto-generated completions for bash, zsh, and fish
               - Dynamic completions for project-specific commands
@@ -48,6 +53,7 @@ presentation:
       content:
         latest_badge_label: Latest
         footer_link_label: All releases on GitHub
+        footer_link_fa_icon: fa-github
         featured_release_ids:
           - v3-2-0
           - v3-1-0
@@ -60,6 +66,8 @@ presentation:
         deliverables_heading: Shipped
         focus_areas_heading: Themes
         footer_link_label: View full roadmap
+        item_fa_icon: fa-check
+        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -90,8 +98,10 @@ presentation:
         banner_prefix: Thanks to all
         contributors_link_label: contributors
         banner_suffix: who helped shape this release.
+        banner_fa_icon: fa-heart
         spotlight:
           - login: sarah-plugins
+            fa_icon: fa-user-astronaut
             summary: Designed and implemented the plugin resolution system from scratch.
           - login: kai-errors
             summary: Rewrote the error pipeline to include structured codes and fix suggestions.
@@ -106,6 +116,11 @@ presentation:
         stats_heading: This quarter
         trend_suffix: vs last quarter
         show_deltas: true
+        stat_fa_icons:
+          - fa-star
+          - fa-check-circle
+          - fa-code-branch
+          - fa-user-plus
         stat_keys:
           - stars
           - issues_closed
@@ -113,6 +128,7 @@ presentation:
           - new_contributors
         mentions:
           - type: Blog post
+            fa_icon: fa-rss
             title: How we built the Vortex plugin system
             url_label: Read on the blog
             url: https://vortex-cli.example.com/blog/plugin-system
@@ -142,14 +158,17 @@ presentation:
         footer_text: Every contribution matters, no matter the size.
         cards:
           - title: Write a plugin
+            fa_icon: fa-code
             description: Build a plugin and publish it to the registry. The plugin guide has templates to get started.
             url_label: Plugin guide
             url: https://vortex-cli.example.com/docs/plugins
           - title: Improve docs
+            fa_icon: fa-book
             description: Help us write better guides, fix typos, or add examples for common workflows.
             url_label: Docs backlog
             url: https://github.com/example/vortex-cli/issues?q=label%3Adocs
           - title: Report bugs
+            fa_icon: fa-bug
             description: Found something broken? File an issue with reproduction steps and we will prioritize it.
             url_label: Open an issue
             url: https://github.com/example/vortex-cli/issues/new
@@ -159,3 +178,6 @@ presentation:
         heading: Thank you
         message: Vortex CLI is built by its community. Every issue, PR, and plugin makes it better for everyone.
         quote: Ship tools, not tickets.
+        repository_fa_icon: fa-github
+        docs_fa_icon: fa-book
+        community_fa_icon: fa-users

--- a/content/presentations/2026-q1/presentation.yaml
+++ b/content/presentations/2026-q1/presentation.yaml
@@ -15,6 +15,8 @@ presentation:
     - template: agenda
       enabled: true
       title: Agenda
+      content:
+        card_arrow_fa_icon: fa-arrow-right
     - template: section-list-grid
       enabled: true
       title: What Happened Since Last Update
@@ -22,6 +24,7 @@ presentation:
       content:
         sections:
           - title: Authoring, templates, and publishing
+            fa_icon: fa-code-branch
             bullets:
               - Reusable briefing templates landed for roadmap, release, and community updates.
               - The content manifest gained clearer metadata for publication windows and owners.
@@ -29,6 +32,7 @@ presentation:
               - Preview routing was tightened for nested presentation paths.
               - The presentation picker now handles larger local archives with predictable ordering.
           - title: Quality, docs, and delivery
+            fa_icon: fa-check-circle
             bullets:
               - Template documentation examples were refreshed to match current rendering behavior.
               - Content validation messages now point authors to the field that needs attention.
@@ -36,6 +40,7 @@ presentation:
               - CI workflow actions were updated to current versions.
               - Contribution guidance now asks for local preview notes before submission.
           - title: Community and usability
+            fa_icon: fa-users
             bullets:
               - Keyboard shortcuts were clarified in the presenter help panel.
               - Empty-state copy was improved for first-run local content.
@@ -49,6 +54,7 @@ presentation:
       content:
         latest_badge_label: Latest
         footer_link_label: View release history on GitHub
+        footer_link_fa_icon: fa-github
         empty_state_title: No tagged releases in this period
         empty_state_message: Q1 work focused on reusable templates, authoring quality, documentation, and release engineering
           improvements rather than a packaged release.
@@ -68,6 +74,8 @@ presentation:
         deliverables_heading: Key deliverables
         focus_areas_heading: Focus areas
         footer_link_label: View full roadmap & milestones on GitHub
+        item_fa_icon: fa-check
+        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -208,8 +216,10 @@ presentation:
         banner_prefix: Special thanks to all
         contributors_link_label: contributors
         banner_suffix: who shipped code, docs, tests, translations, and roadmap work during Q1 2026.
+        banner_fa_icon: fa-heart
         spotlight:
           - login: river-park
+            fa_icon: fa-user-astronaut
             summary: Delivered reusable briefing templates for roadmap and release updates, then followed through with preview
               routing and documentation fixes.
           - login: mint-owl
@@ -224,6 +234,13 @@ presentation:
         section_heading: Community Activity
         stats_heading: Stats This Quarter
         trend_suffix: vs previous period
+        section_heading_fa_icon: fa-bullhorn
+        stats_heading_fa_icon: fa-chart-line
+        stat_fa_icons:
+          - fa-star
+          - fa-check-circle
+          - fa-code-branch
+          - fa-user-plus
         stat_keys:
           - stars
           - issues_closed
@@ -231,6 +248,7 @@ presentation:
           - new_contributors
         mentions:
           - type: Public roadmap
+            fa_icon: fa-rss
             title: Aurora Notes' public planning board opened in March 2026 with themes for maintainability, team readiness,
               UX/accessibility, publishing workflows, and community confidence.
             url_label: Join the GitHub discussion
@@ -265,23 +283,28 @@ presentation:
       subtitle: Practical ways to contribute code, docs, testing, and feedback
       content:
         footer_text: Open Source and Community Driven
+        footer_fa_icon: fa-github
         cards:
           - title: Report Bugs
+            fa_icon: fa-bug
             description: File a reproducible issue with environment details, screenshots, and any project or stack context that helps
               maintainers confirm the problem.
             url_label: Submit an issue
             url: https://github.com/example-org/aurora-notes/issues
           - title: Submit Code
+            fa_icon: fa-code-branch
             description: Pick up a tracked issue, fork the repository, and submit a pull request that includes the manual testing
               now required in the contribution guide.
             url_label: Read CONTRIBUTING.md
             url: https://github.com/example-org/aurora-notes/blob/main/CONTRIBUTING.md
           - title: Improve Docs
+            fa_icon: fa-book
             description: Improve installation docs, schema guidance, deployment notes, or contributor documentation so users can
               adopt Aurora Notes more easily.
             url_label: Edit docs on GitHub
             url: https://github.com/example-org/aurora-notes
           - title: Spread the Word
+            fa_icon: fa-bullhorn
             description: Join the roadmap discussion, share your usage patterns, star the repository, or help connect Aurora Notes
               to adjacent open-source workflows.
             url_label: Share & Star
@@ -292,3 +315,6 @@ presentation:
         heading: Thank you
         message: See you in the next update.
         quote: making project updates easier to share
+        repository_fa_icon: fa-github
+        docs_fa_icon: fa-book
+        community_fa_icon: fa-globe

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -33,6 +33,7 @@ export default defineConfig({
       { text: 'Quickstart', link: '/quickstart' },
       { text: 'Presenting', link: '/presenting' },
       { text: 'Concepts', link: '/concepts' },
+      { text: 'Reference', link: '/reference/fontawesome', activeMatch: '^/reference' },
       { text: 'Schema', link: '/schema/', activeMatch: '^/schema' },
       { text: 'Templates', link: '/templates/', activeMatch: '^/templates' },
       { text: 'CLI', link: '/cli/', activeMatch: '^/cli' },
@@ -50,6 +51,14 @@ export default defineConfig({
             { text: 'presentations/index.yaml', link: '/schema/presentations-index' },
             { text: 'presentation.yaml', link: '/schema/presentation' },
             { text: 'generated.yaml', link: '/schema/generated' },
+          ],
+        },
+      ],
+      '/reference/': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'Font Awesome Icons', link: '/reference/fontawesome' },
           ],
         },
       ],

--- a/docs/.vitepress/theme/FontAwesomeIconReference.vue
+++ b/docs/.vitepress/theme/FontAwesomeIconReference.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import { fontAwesomeIconDefinitions } from '../../../shared/src/fontawesome'
+
+const query = ref('')
+
+const filteredIcons = computed(() => {
+  const normalizedQuery = query.value.trim().toLowerCase()
+
+  if (!normalizedQuery) return fontAwesomeIconDefinitions
+
+  return fontAwesomeIconDefinitions.filter((icon) => {
+    const searchableText = `${icon.canonical} ${icon.label}`.toLowerCase()
+
+    return searchableText.includes(normalizedQuery)
+  })
+})
+
+function iconClass(icon: (typeof fontAwesomeIconDefinitions)[number]): string {
+  const styleClass = icon.style === 'brands' ? 'fa-brands' : 'fa-solid'
+
+  return `${styleClass} ${icon.canonical}`
+}
+</script>
+
+<template>
+  <section class="fontawesome-reference" aria-labelledby="fontawesome-reference-title">
+    <div class="fontawesome-reference__search">
+      <label id="fontawesome-reference-title" for="fontawesome-icon-search">Search supported icons</label>
+      <input
+        id="fontawesome-icon-search"
+        v-model="query"
+        type="search"
+        placeholder="Search by name or YAML value, e.g. github or fa-code"
+      />
+    </div>
+
+    <p class="fontawesome-reference__count">
+      Showing {{ filteredIcons.length }} of {{ fontAwesomeIconDefinitions.length }} supported icons.
+    </p>
+
+    <div v-if="filteredIcons.length > 0" class="fontawesome-reference__grid">
+      <article
+        v-for="icon in filteredIcons"
+        :key="icon.canonical"
+        class="fontawesome-reference__card"
+        :aria-label="`${icon.label}: ${icon.canonical}`"
+      >
+        <span class="fontawesome-reference__preview" aria-hidden="true">
+          <i :class="iconClass(icon)"></i>
+        </span>
+        <span class="fontawesome-reference__label">{{ icon.label }}</span>
+        <code>{{ icon.canonical }}</code>
+      </article>
+    </div>
+
+    <p v-else class="fontawesome-reference__empty">No supported icons match this search.</p>
+  </section>
+</template>
+
+<style scoped>
+.fontawesome-reference {
+  margin: 1.25rem 0 2rem;
+}
+
+.fontawesome-reference__search {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 0.75rem;
+}
+
+.fontawesome-reference__search label {
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+}
+
+.fontawesome-reference__search input {
+  width: 100%;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  padding: 0.7rem 0.85rem;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+}
+
+.fontawesome-reference__search input:focus {
+  border-color: var(--vp-c-brand-1);
+  outline: 3px solid color-mix(in srgb, var(--vp-c-brand-1) 24%, transparent);
+}
+
+.fontawesome-reference__count,
+.fontawesome-reference__empty {
+  color: var(--vp-c-text-2);
+}
+
+.fontawesome-reference__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(145px, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.fontawesome-reference__card {
+  display: grid;
+  gap: 0.45rem;
+  align-content: start;
+  min-height: 8.5rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
+  padding: 0.85rem;
+  background: linear-gradient(145deg, var(--vp-c-bg-soft), var(--vp-c-bg));
+}
+
+.fontawesome-reference__preview {
+  display: grid;
+  place-items: center;
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 999px;
+  color: var(--vp-c-brand-1);
+  background: color-mix(in srgb, var(--vp-c-brand-1) 12%, transparent);
+  font-size: 1.25rem;
+}
+
+.fontawesome-reference__label {
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--vp-c-text-1);
+}
+
+.fontawesome-reference__card code {
+  width: fit-content;
+  white-space: normal;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,9 +1,14 @@
 import DefaultTheme from 'vitepress/theme'
+import '@fortawesome/fontawesome-free/css/all.min.css'
 
+import FontAwesomeIconReference from './FontAwesomeIconReference.vue'
 import Layout from './Layout.vue'
 import './custom.css'
 
 export default {
   extends: DefaultTheme,
   Layout,
+  enhanceApp({ app }) {
+    app.component('FontAwesomeIconReference', FontAwesomeIconReference)
+  },
 }

--- a/docs/fixtures/reference-project/content/presentations/2026-spring-briefing/presentation.yaml
+++ b/docs/fixtures/reference-project/content/presentations/2026-spring-briefing/presentation.yaml
@@ -17,6 +17,8 @@ presentation:
       enabled: true
       title: Agenda
       subtitle: What this briefing covers
+      content:
+        card_arrow_fa_icon: fa-arrow-right
     - template: section-list-grid
       enabled: true
       title: What shipped
@@ -24,16 +26,19 @@ presentation:
       content:
         sections:
           - title: Launch workflow
+            fa_icon: fa-check-circle
             bullets:
               - Starter checklists now include task ownership and sign-off states.
               - PDF exports now preserve section grouping for external reviews.
               - Deployment notes are easier to scan on large screens.
           - title: Documentation
+            fa_icon: fa-book
             bullets:
               - New rollout docs cover shared templates and review-mode exports.
               - Migration notes now map old checklist fields to the new schema.
               - Internal examples now match the live generated data model.
           - title: Quality
+            fa_icon: fa-wrench
             bullets:
               - Shared rendering components now have broader test coverage.
               - Example data fixtures were refreshed to match the current schema.
@@ -45,6 +50,7 @@ presentation:
       content:
         latest_badge_label: Latest
         footer_link_label: Browse the release archive
+        footer_link_fa_icon: fa-github
         featured_release_ids:
           - starter-kit-v2
           - export-layout-v1
@@ -64,6 +70,8 @@ presentation:
         deliverables_heading: Key deliverables
         focus_areas_heading: Focus areas
         footer_link_label: View roadmap on GitHub
+        item_fa_icon: fa-check
+        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -94,8 +102,10 @@ presentation:
         banner_prefix: Thanks to
         contributors_link_label: contributors
         banner_suffix: who handled product delivery, export polish, and rollout docs this season.
+        banner_fa_icon: fa-heart
         spotlight:
           - login: ava-product
+            fa_icon: fa-user-astronaut
             summary: Defined the starter-kit structure and coordinated the rollout checklist overhaul.
           - login: mo-rendering
             summary: Improved export polish, spacing, and rendering behavior for PDF output.
@@ -110,6 +120,11 @@ presentation:
         stats_heading: This period
         trend_suffix: vs previous period
         show_deltas: true
+        stat_fa_icons:
+          - fa-star
+          - fa-check-circle
+          - fa-code-branch
+          - fa-user-plus
         stat_keys:
           - stars
           - issues_closed
@@ -117,6 +132,7 @@ presentation:
           - new_contributors
         mentions:
           - type: Case study
+            fa_icon: fa-rss
             title: The customer rollout playbook now includes the new checklist workflow and export review cadence.
             url_label: Read the guide
             url: https://example.com/docs/rollout-playbook
@@ -146,14 +162,17 @@ presentation:
         footer_text: Contribution options stay lightweight on purpose.
         cards:
           - title: Review docs
+            fa_icon: fa-book
             description: Tighten rollout notes, migration steps, and operator checklists before the next update ships.
             url_label: Open docs backlog
             url: https://example.com/docs/backlog
           - title: Test templates
+            fa_icon: fa-check
             description: Run a real project through the starter kit and record anything that feels unclear or repetitive.
             url_label: Report template feedback
             url: https://example.com/feedback/templates
           - title: Improve exports
+            fa_icon: fa-wrench
             description: Review generated PDFs and suggest improvements to spacing, hierarchy, and readability.
             url_label: Share export feedback
             url: https://example.com/feedback/exports
@@ -163,3 +182,6 @@ presentation:
         heading: Thank you
         message: Keep the schema honest, keep the examples real, and the slides stay easy to trust.
         quote: YAML in, static site out.
+        repository_fa_icon: fa-github
+        docs_fa_icon: fa-book
+        community_fa_icon: fa-globe

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "catalog:",
+    "@fortawesome/fontawesome-free": "catalog:",
     "@playwright/test": "catalog:",
     "playwright": "catalog:",
     "tsx": "catalog:",

--- a/docs/reference/fontawesome.md
+++ b/docs/reference/fontawesome.md
@@ -1,0 +1,28 @@
+# Font Awesome Icons
+
+Slide Spec validates every `fa_icon` and `*_fa_icon` YAML field against this supported icon set.
+
+Use the canonical value in YAML:
+
+```yaml
+fa_icon: fa-code
+```
+
+Brand icons use the same simple form:
+
+```yaml
+fa_icon: fa-github
+```
+
+The validator also accepts explicit Font Awesome style prefixes such as `fa-solid fa-code`, `fas fa-code`, `fa-brands fa-github`, and `fab fa-github`. Prefer the canonical value unless you need to be explicit for compatibility with existing content.
+
+## Supported Icons
+
+<FontAwesomeIconReference />
+
+## Schema Usage
+
+All public schemas reference `defs.schema.json#/$defs/fontAwesomeIcon` for icon fields. Template docs list the default for each slot so authors can omit icon fields unless they need a different visual.
+
+_FontAwesome has **many** more icons available. We do not import the entire set to keep the bundled CLI and static app size smaller. If you need any specific icons imported, please [open an issue](https://github.com/lreading/slide-spec/issues) with the icon name.
+

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -24,6 +24,8 @@ schemaVersion: 1
 
 The public JSON Schemas are maintained to mirror Slide Spec runtime validation and make editors more useful while you author content. Use `slide-spec validate` as the authoritative project validation path before publishing.
 
+Fields named `fa_icon` or ending in `_fa_icon` validate against the supported [Font Awesome icon reference](/reference/fontawesome).
+
 Use the specific schema for each file when you know the document type:
 
 | File | Schema URL |

--- a/docs/schema/presentation.md
+++ b/docs/schema/presentation.md
@@ -6,6 +6,8 @@ For a complete example, see the [reference presentation.yaml](https://github.com
 
 Each slide owns its own `content` block. If two slides need the same copy or labels, repeat them on those slides rather than relying on shared presentation-level data.
 
+Icon fields named `fa_icon` or ending in `_fa_icon` accept supported Font Awesome values from the [Font Awesome icon reference](/reference/fontawesome). All icon fields are optional and keep their documented defaults when omitted.
+
 ## Top level
 
 ```yaml
@@ -34,6 +36,10 @@ The [progress-timeline](/templates/progress-timeline) template is self-contained
 | `content.deliverables_heading` | | string |
 | `content.focus_areas_heading` | | string |
 | `content.footer_link_label` | | string |
+| `content.item_fa_icon` | | string |
+| `content.focus_areas_fa_icon` | | string |
+| `content.theme_fa_icon` | | string |
+| `content.footer_link_fa_icon` | | string |
 | `content.stages` | yes | object |
 | `content.items` | yes | string[] |
 | `content.themes` | yes | array of `{ category, target }` |
@@ -90,7 +96,8 @@ Slide-level `title` is not required.
 | Field | Required | Notes |
 | --- | --- | --- |
 | `title` | yes | |
-| `content` | | Omit entirely or pass `{}`. Row text comes from other slides |
+| `content` | | Omit entirely or configure `content.card_arrow_fa_icon`. Row text comes from other slides |
+| `content.card_arrow_fa_icon` | | Defaults to `fa-chevron-right` |
 
 ### section-title
 
@@ -110,6 +117,8 @@ Slide-level `title` is not required.
 
 Each `sections[]` entry: `{ title: string, bullets: string[] }`.
 
+Each `sections[]` entry may also set `fa_icon` to override its badge icon.
+
 ### timeline
 
 | Field | Required | Notes |
@@ -120,6 +129,9 @@ Each `sections[]` entry: `{ title: string, bullets: string[] }`.
 | `content.footer_link_label` | | |
 | `content.empty_state_title` | | |
 | `content.empty_state_message` | | |
+| `content.latest_release_fa_icon` | | Defaults to `fa-tag` |
+| `content.release_fa_icon` | | Defaults to `fa-code-branch` |
+| `content.footer_link_fa_icon` | | Defaults to `fa-github` |
 
 ### progress-timeline
 
@@ -130,35 +142,47 @@ Each `sections[]` entry: `{ title: string, bullets: string[] }`.
 | `content.deliverables_heading` | | |
 | `content.focus_areas_heading` | | |
 | `content.footer_link_label` | | |
+| `content.item_fa_icon` | | Defaults to `fa-chevron-right` |
+| `content.focus_areas_fa_icon` | | Defaults to `fa-bullseye` |
+| `content.theme_fa_icon` | | Defaults to `fa-chevron-right` |
+| `content.footer_link_fa_icon` | | Defaults to `fa-github` |
 | `content.stages` | yes | Four stage strip entries |
 | `content.items` | yes | Active stage items |
 | `content.themes` | yes | Active stage themes |
 
 ### people
 
-| Field | Required |
-| --- | --- |
-| `title` | yes |
-| `content.spotlight` | yes |
-| `content.banner_prefix` | |
-| `content.contributors_link_label` | |
-| `content.banner_suffix` | |
+| Field | Required | Notes |
+| --- | --- | --- |
+| `title` | yes | |
+| `content.spotlight` | yes | |
+| `content.banner_prefix` | | |
+| `content.contributors_link_label` | | |
+| `content.banner_suffix` | | |
+| `content.github_fa_icon` | | Defaults to `fa-github` |
+| `content.quote_fa_icon` | | Defaults to `fa-quote-left` |
+| `content.banner_fa_icon` | | Defaults to `fa-heart` |
 
-Each `spotlight[]` entry: `{ login: string, summary: string }`.
+Each `spotlight[]` entry: `{ login: string, summary: string }` with optional `fa_icon`.
 
 ### metrics-and-links
 
-| Field | Required |
-| --- | --- |
-| `title` | yes |
-| `content.stat_keys` | yes |
-| `content.mentions` | yes |
-| `content.section_heading` | |
-| `content.stats_heading` | |
-| `content.show_deltas` | |
-| `content.trend_suffix` | |
+| Field | Required | Notes |
+| --- | --- | --- |
+| `title` | yes | |
+| `content.stat_keys` | yes | |
+| `content.mentions` | yes | |
+| `content.section_heading` | | |
+| `content.stats_heading` | | |
+| `content.show_deltas` | | |
+| `content.trend_suffix` | | |
+| `content.section_heading_fa_icon` | | Defaults to `fa-bullhorn` |
+| `content.stats_heading_fa_icon` | | Defaults to `fa-chart-line` |
+| `content.stat_fa_icons` | | Optional string array matched to `stat_keys` order |
+| `content.trend_up_fa_icon` | | Defaults to `fa-arrow-up` |
+| `content.trend_down_fa_icon` | | Defaults to `fa-arrow-down` |
 
-Each `mentions[]` entry: `{ type: string, title: string }` with optional paired `url` + `url_label`.
+Each `mentions[]` entry: `{ type: string, title: string }` with optional paired `url` + `url_label`, optional `fa_icon`, and optional `link_fa_icon`.
 
 ### image-and-bullets
 
@@ -175,13 +199,15 @@ When present, `image` has shape: `{ src: string, alt?: string, description?: str
 
 ### action-cards
 
-| Field | Required |
-| --- | --- |
-| `title` | yes |
-| `content.cards` | yes |
-| `content.footer_text` | |
+| Field | Required | Notes |
+| --- | --- | --- |
+| `title` | yes | |
+| `content.cards` | yes | |
+| `content.footer_text` | | |
+| `content.footer_fa_icon` | | Defaults to `fa-github` |
+| `content.footer_link_fa_icon` | | Defaults to `fa-code` |
 
-Each `cards[]` entry: `{ title, description, url_label, url }` (all required strings).
+Each `cards[]` entry: `{ title, description, url_label, url }` (all required strings) with optional `fa_icon` and `link_fa_icon`.
 
 ### closing
 
@@ -190,5 +216,8 @@ Each `cards[]` entry: `{ title, description, url_label, url }` (all required str
 | `content.heading` | yes | |
 | `content.message` | yes | |
 | `content.quote` | | |
+| `content.repository_fa_icon` | | Defaults to `fa-github` |
+| `content.docs_fa_icon` | | Defaults to `fa-book` |
+| `content.community_fa_icon` | | Defaults to `fa-shield-alt` |
 
 Slide-level `title` is not required.

--- a/docs/schema/site.md
+++ b/docs/schema/site.md
@@ -106,7 +106,7 @@ Each link object:
 | Field | Required | Type | Notes |
 | --- | --- | --- | --- |
 | `label` | | string | Badge text |
-| `fa_icon` | | string | Font Awesome class (e.g. `fa-code`) |
+| `fa_icon` | | string | Supported Font Awesome icon from the [icon reference](/reference/fontawesome), e.g. `fa-code` |
 | `icon_position` | | string | `before` or `after` |
 
 At least one of `label` or `fa_icon` must be present.

--- a/docs/scripts/documentation-manifest.ts
+++ b/docs/scripts/documentation-manifest.ts
@@ -29,7 +29,7 @@ export const documentationSections: DocumentationSection[] = [
         description: 'Core mental model for content structure, template-driven slides, generated data, and validation.',
       },
       {
-        path: '/presentation-mode',
+        path: '/presenting',
         title: 'Presentation mode guide',
         description: 'How slide navigation, viewport mode, fullscreen mode, keyboard controls, and callout persistence work.',
       },
@@ -62,6 +62,16 @@ export const documentationSections: DocumentationSection[] = [
         path: '/schema/generated',
         title: 'generated.yaml schema',
         description: 'Generated or manually authored metrics, releases, contributors, and other computed content.',
+      },
+    ],
+  },
+  {
+    title: 'Field Reference',
+    resources: [
+      {
+        path: '/reference/fontawesome',
+        title: 'Font Awesome icon reference',
+        description: 'Supported fa_icon values, accepted aliases, and workspace Font Awesome package versions.',
       },
     ],
   },

--- a/docs/templates/action-cards.md
+++ b/docs/templates/action-cards.md
@@ -15,8 +15,12 @@ Grid of CTA cards with an optional footer strip.
   subtitle: Ways to support the next cycle
   content:
     footer_text: Contribution options stay lightweight on purpose.
+    footer_fa_icon: fa-github
+    footer_link_fa_icon: fa-code
     cards:
       - title: Review docs
+        fa_icon: fa-book
+        link_fa_icon: fa-arrow-right
         description: Tighten rollout notes and operator checklists.
         url_label: Open docs backlog
         url: https://example.com/docs/backlog
@@ -46,6 +50,8 @@ Grid of CTA cards with an optional footer strip.
 | `title` | yes | string |
 | `subtitle` | | string |
 | `content.footer_text` | | string |
+| `content.footer_fa_icon` | | string |
+| `content.footer_link_fa_icon` | | string |
 | `content.cards` | yes | array |
 
 ### `content.cards[]`
@@ -56,3 +62,7 @@ Grid of CTA cards with an optional footer strip.
 | `description` | yes | string |
 | `url_label` | yes | string |
 | `url` | yes | string |
+| `fa_icon` | | string |
+| `link_fa_icon` | | string |
+
+Icon defaults are `fa-bug`, `fa-code-branch`, `fa-book`, and `fa-bullhorn` for cards, `fa-arrow-right`, `fa-arrow-right`, `fa-arrow-right`, and `fa-star` for card links, `fa-github` for the footer strip, and `fa-code` for the footer button. Additional cards default to `fa-star`, and additional card links default to `fa-arrow-right`. Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/docs/templates/agenda.md
+++ b/docs/templates/agenda.md
@@ -13,6 +13,8 @@ Auto-generated table of contents. Each row comes from a later enabled slide in t
   enabled: true
   title: Agenda
   subtitle: What this briefing covers
+  content:
+    card_arrow_fa_icon: fa-arrow-right
 ```
 
 ## How rows are generated
@@ -28,4 +30,7 @@ Row labels come from each subsequent enabled slide's `title`. Two exceptions:
 | --- | --- | --- |
 | `title` | yes | string |
 | `subtitle` | | string |
-| `content` | | Omit or `{}` |
+| `content` | | object |
+| `content.card_arrow_fa_icon` | | string |
+
+`content.card_arrow_fa_icon` defaults to `fa-chevron-right`. Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/docs/templates/closing.md
+++ b/docs/templates/closing.md
@@ -15,6 +15,9 @@ Final slide with heading, message, optional quote, resource links, and optional 
     heading: Thank you
     message: Keep the schema honest and the examples real.
     quote: YAML in, static site out.
+    repository_fa_icon: fa-github
+    docs_fa_icon: fa-book
+    community_fa_icon: fa-shield-alt
 ```
 
 ## Data sources
@@ -34,5 +37,10 @@ Final slide with heading, message, optional quote, resource links, and optional 
 | `content.heading` | yes | string |
 | `content.message` | yes | string |
 | `content.quote` | | string |
+| `content.repository_fa_icon` | | string |
+| `content.docs_fa_icon` | | string |
+| `content.community_fa_icon` | | string |
 
 Slide-level `title` is not required.
+
+Icon defaults are `fa-github` for the repository pill, `fa-book` for the docs pill, and `fa-shield-alt` for the community pill. Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/docs/templates/index.md
+++ b/docs/templates/index.md
@@ -31,6 +31,10 @@ site:
 
 The corner mark combines `site.presentation_chrome.mark_label` with `presentation.subtitle` from the deck.
 
+## Template icons
+
+Templates that render Font Awesome icons expose optional `fa_icon` or `*_fa_icon` fields in their YAML content. Omit these fields to keep the template defaults. Set them only when a slide needs more specific iconography. Supported values are listed in the [Font Awesome icon reference](/reference/fontawesome).
+
 ## Slide structure
 
 Every slide shares this envelope in `presentation.yaml`:

--- a/docs/templates/metrics-and-links.md
+++ b/docs/templates/metrics-and-links.md
@@ -20,6 +20,13 @@ Two-column layout: authored mention cards on the left, metric tiles on the right
     stats_heading: This period
     trend_suffix: vs previous period
     show_deltas: true
+    section_heading_fa_icon: fa-bullhorn
+    stats_heading_fa_icon: fa-chart-line
+    stat_fa_icons:
+      - fa-star
+      - fa-check-circle
+      - fa-code-branch
+      - fa-user-plus
     stat_keys:
       - stars
       - issues_closed
@@ -27,6 +34,8 @@ Two-column layout: authored mention cards on the left, metric tiles on the right
       - new_contributors
     mentions:
       - type: Case study
+        fa_icon: fa-rss
+        link_fa_icon: fa-external-link-alt
         title: The rollout playbook now includes the new checklist workflow.
         url_label: Read the guide
         url: https://example.com/docs/rollout-playbook
@@ -81,6 +90,11 @@ generated:
 | `content.stats_heading` | | string |
 | `content.show_deltas` | | boolean |
 | `content.trend_suffix` | | string |
+| `content.section_heading_fa_icon` | | string |
+| `content.stats_heading_fa_icon` | | string |
+| `content.stat_fa_icons` | | string[] |
+| `content.trend_up_fa_icon` | | string |
+| `content.trend_down_fa_icon` | | string |
 
 ### `content.mentions[]`
 
@@ -90,5 +104,9 @@ generated:
 | `title` | yes | string |
 | `url_label` | | string |
 | `url` | | string |
+| `fa_icon` | | string |
+| `link_fa_icon` | | string |
 
 `url` and `url_label` are paired: set both or omit both. Mentions without links render as plain text cards.
+
+Icon defaults are `fa-bullhorn` for the mentions heading, `fa-chart-line` for the stats heading, `fa-microphone-alt`, `fa-rss`, and `fa-podcast` for mention cards, `fa-external-link-alt` for mention links, `fa-star`, `fa-check-circle`, `fa-code-branch`, and `fa-user-plus` for stat cards, and `fa-arrow-up` / `fa-arrow-down` for trends. Additional mentions default to `fa-rss`; additional stats default to `fa-star`. Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/docs/templates/people.md
+++ b/docs/templates/people.md
@@ -19,8 +19,12 @@ Contributor spotlight cards. Each `spotlight` entry is resolved against `generat
     banner_prefix: Thanks to
     contributors_link_label: contributors
     banner_suffix: who drove this release forward.
+    github_fa_icon: fa-github
+    quote_fa_icon: fa-quote-left
+    banner_fa_icon: fa-heart
     spotlight:
       - login: ava-product
+        fa_icon: fa-user-astronaut
         summary: Defined the starter-kit structure and led the checklist overhaul.
       - login: mo-rendering
         summary: Improved export polish and PDF spacing.
@@ -67,6 +71,9 @@ generated:
 | `content.banner_prefix` | | string |
 | `content.contributors_link_label` | | string |
 | `content.banner_suffix` | | string |
+| `content.github_fa_icon` | | string |
+| `content.quote_fa_icon` | | string |
+| `content.banner_fa_icon` | | string |
 | `content.spotlight` | yes | array |
 
 ### `content.spotlight[]`
@@ -75,5 +82,8 @@ generated:
 | --- | --- | --- |
 | `login` | yes | string |
 | `summary` | yes | string |
+| `fa_icon` | | string |
 
 If a `login` has no match in `generated.contributors.authors[]`, the card renders using the login as the display name.
+
+Icon defaults are `fa-user-astronaut`, `fa-user-ninja`, and `fa-user-secret` for profile cards, `fa-github` for handles, `fa-quote-left` for quote decoration, and `fa-heart` for the banner. Additional profile cards default to `fa-user-secret`. Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/docs/templates/progress-timeline.md
+++ b/docs/templates/progress-timeline.md
@@ -20,6 +20,10 @@ Focuses a single stage. Each slide carries its own stage headings and four stage
     deliverables_heading: Key deliverables
     focus_areas_heading: Focus areas
     footer_link_label: View roadmap on GitHub
+    item_fa_icon: fa-check
+    focus_areas_fa_icon: fa-bullseye
+    theme_fa_icon: fa-chevron-right
+    footer_link_fa_icon: fa-github
     stages:
       completed:
         label: Completed
@@ -65,8 +69,14 @@ If `subtitle` is omitted, the active stage's `summary` is used instead.
 | `content.deliverables_heading` | | string | |
 | `content.focus_areas_heading` | | string | |
 | `content.footer_link_label` | | string | |
+| `content.item_fa_icon` | | string | Defaults to `fa-chevron-right` |
+| `content.focus_areas_fa_icon` | | string | Defaults to `fa-bullseye` |
+| `content.theme_fa_icon` | | string | Defaults to `fa-chevron-right` |
+| `content.footer_link_fa_icon` | | string | Defaults to `fa-github` |
 | `content.stages` | yes | object | Four stage strip entries |
 | `content.items` | yes | string[] | Active stage items |
 | `content.themes` | yes | array | Active stage themes |
 
 The progress timeline schema is documented in [presentation.yaml](/schema/presentation#progress-timeline).
+
+Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/docs/templates/section-list-grid.md
+++ b/docs/templates/section-list-grid.md
@@ -16,10 +16,12 @@ Grid of titled sections, each with a heading and bullet list.
   content:
     sections:
       - title: Launch workflow
+        fa_icon: fa-check-circle
         bullets:
           - Starter checklists now include task ownership.
           - PDF exports preserve section grouping.
       - title: Documentation
+        fa_icon: fa-book
         bullets:
           - New rollout docs cover shared templates.
           - Migration notes map old fields to the new schema.
@@ -39,3 +41,6 @@ Grid of titled sections, each with a heading and bullet list.
 | --- | --- | --- |
 | `title` | yes | string |
 | `bullets` | yes | string[] |
+| `fa_icon` | | string |
+
+`fa_icon` overrides the section badge icon. Defaults are assigned by section order: `fa-wrench`, `fa-star`, then `fa-users`, with `fa-star` for additional sections. Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/docs/templates/timeline.md
+++ b/docs/templates/timeline.md
@@ -18,6 +18,9 @@ Release cards populated from `generated.yaml`. Each card in `featured_release_id
   content:
     latest_badge_label: Latest
     footer_link_label: Browse the release archive
+    latest_release_fa_icon: fa-tag
+    release_fa_icon: fa-code-branch
+    footer_link_fa_icon: fa-github
     featured_release_ids:
       - starter-kit-v2
       - export-layout-v1
@@ -64,5 +67,10 @@ generated:
 | `content.footer_link_label` | | string |
 | `content.empty_state_title` | | string |
 | `content.empty_state_message` | | string |
+| `content.latest_release_fa_icon` | | string |
+| `content.release_fa_icon` | | string |
+| `content.footer_link_fa_icon` | | string |
 
 IDs with no matching `generated.releases[]` entry are skipped. An empty `featured_release_ids` array shows the empty state copy if provided.
+
+Icon defaults are `fa-tag` for the first release, `fa-code-branch` for later releases, and `fa-github` for the footer link. Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/examples/open-source-update/content/presentations/2026-q1-update/presentation.yaml
+++ b/examples/open-source-update/content/presentations/2026-q1-update/presentation.yaml
@@ -20,6 +20,8 @@ presentation:
       enabled: true
       title: Agenda
       subtitle: What this update covers
+      content:
+        card_arrow_fa_icon: fa-arrow-right
     - template: section-list-grid
       enabled: true
       title: What shipped
@@ -27,16 +29,19 @@ presentation:
       content:
         sections:
           - title: Plugin system
+            fa_icon: fa-code-branch
             bullets:
               - Local plugins resolve from the project directory
               - Registry plugins install from the public catalog
               - Lifecycle hooks for init, build, and deploy phases
           - title: Error messages
+            fa_icon: fa-bug
             bullets:
               - Structured output with error codes and fix suggestions
               - Links to relevant documentation in every error
               - Machine-readable JSON output for CI pipelines
           - title: Shell completions
+            fa_icon: fa-wrench
             bullets:
               - Auto-generated completions for bash, zsh, and fish
               - Dynamic completions for project-specific commands
@@ -48,6 +53,7 @@ presentation:
       content:
         latest_badge_label: Latest
         footer_link_label: All releases on GitHub
+        footer_link_fa_icon: fa-github
         featured_release_ids:
           - v3-2-0
           - v3-1-0
@@ -60,6 +66,8 @@ presentation:
         deliverables_heading: Shipped
         focus_areas_heading: Themes
         footer_link_label: View full roadmap
+        item_fa_icon: fa-check
+        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -90,8 +98,10 @@ presentation:
         banner_prefix: Thanks to all
         contributors_link_label: contributors
         banner_suffix: who helped shape this release.
+        banner_fa_icon: fa-heart
         spotlight:
           - login: sarah-plugins
+            fa_icon: fa-user-astronaut
             summary: Designed and implemented the plugin resolution system from scratch.
           - login: kai-errors
             summary: Rewrote the error pipeline to include structured codes and fix suggestions.
@@ -106,6 +116,11 @@ presentation:
         stats_heading: This quarter
         trend_suffix: vs last quarter
         show_deltas: true
+        stat_fa_icons:
+          - fa-star
+          - fa-check-circle
+          - fa-code-branch
+          - fa-user-plus
         stat_keys:
           - stars
           - issues_closed
@@ -113,6 +128,7 @@ presentation:
           - new_contributors
         mentions:
           - type: Blog post
+            fa_icon: fa-rss
             title: How we built the Vortex plugin system
             url_label: Read on the blog
             url: https://vortex-cli.example.com/blog/plugin-system
@@ -142,14 +158,17 @@ presentation:
         footer_text: Every contribution matters, no matter the size.
         cards:
           - title: Write a plugin
+            fa_icon: fa-code
             description: Build a plugin and publish it to the registry. The plugin guide has templates to get started.
             url_label: Plugin guide
             url: https://vortex-cli.example.com/docs/plugins
           - title: Improve docs
+            fa_icon: fa-book
             description: Help us write better guides, fix typos, or add examples for common workflows.
             url_label: Docs backlog
             url: https://github.com/example/vortex-cli/issues?q=label%3Adocs
           - title: Report bugs
+            fa_icon: fa-bug
             description: Found something broken? File an issue with reproduction steps and we will prioritize it.
             url_label: Open an issue
             url: https://github.com/example/vortex-cli/issues/new
@@ -159,3 +178,6 @@ presentation:
         heading: Thank you
         message: Vortex CLI is built by its community. Every issue, PR, and plugin makes it better for everyone.
         quote: Ship tools, not tickets.
+        repository_fa_icon: fa-github
+        docs_fa_icon: fa-book
+        community_fa_icon: fa-users

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,9 @@ importers:
       '@axe-core/playwright':
         specifier: 'catalog:'
         version: 4.11.3(playwright-core@1.60.0)
+      '@fortawesome/fontawesome-free':
+        specifier: 'catalog:'
+        version: 7.2.0
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0

--- a/shared/src/content-validator.spec.ts
+++ b/shared/src/content-validator.spec.ts
@@ -245,6 +245,12 @@ describe('ContentValidator', () => {
     expect(() =>
       validator.validateSiteDocument({
         schemaVersion: SLIDE_SPEC_SCHEMA_VERSION,
+        site: { ...validSiteDocument.site, project_badge: { label: 'Badge', fa_icon: 'fa-nope' } },
+      }),
+    ).toThrow('site.yaml.site.project_badge.fa_icon must be a supported Font Awesome icon.')
+    expect(() =>
+      validator.validateSiteDocument({
+        schemaVersion: SLIDE_SPEC_SCHEMA_VERSION,
         site: { ...validSiteDocument.site, navigation: { docs_enabled: 'true' } },
       }),
     ).toThrow('site.yaml.site.navigation.docs_enabled must be a boolean.')
@@ -365,7 +371,7 @@ describe('ContentValidator', () => {
           slides: [{ template: 'agenda', enabled: true, title: 'Agenda', content: { extra: true } }],
         },
       }),
-    ).toThrow('presentation document.presentation.slides[0].content must be omitted or an empty object for agenda slides.')
+    ).toThrow('presentation document.presentation.slides[0].content.extra is not allowed.')
     expect(() =>
       validator.validateGeneratedDocument({
         schemaVersion: SLIDE_SPEC_SCHEMA_VERSION,

--- a/shared/src/content-validator.ts
+++ b/shared/src/content-validator.ts
@@ -4,6 +4,7 @@ import { validateTemplateSlide } from './templates/validation'
 import {
   assert,
   assertBoolean,
+  assertOptionalFontAwesomeIcon,
   assertNoUnexpectedKeys,
   assertNonBlankString,
   assertNumber,
@@ -46,7 +47,7 @@ function assertProjectBadge(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
   assertNoUnexpectedKeys(value, ['label', 'fa_icon', 'icon_position'], path)
   assertOptionalString(value.label, `${path}.label`)
-  assertOptionalString(value.fa_icon, `${path}.fa_icon`)
+  assertOptionalFontAwesomeIcon(value.fa_icon, `${path}.fa_icon`)
   assertOptionalString(value.icon_position, `${path}.icon_position`)
   assert(value.label !== undefined || value.fa_icon !== undefined, `${path} must include label or fa_icon.`)
   if (value.icon_position !== undefined) {
@@ -304,10 +305,6 @@ function validateSlide(value: unknown, path: string): void {
   if (value.template === 'agenda') {
     if (value.content !== undefined) {
       assert(isRecord(value.content), `${path}.content must be an object.`)
-      assert(
-        Object.keys(value.content).length === 0,
-        `${path}.content must be omitted or an empty object for agenda slides.`,
-      )
     }
   } else {
     assert(isRecord(value.content), `${path}.content must be an object.`)

--- a/shared/src/fontawesome.spec.ts
+++ b/shared/src/fontawesome.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  acceptedFontAwesomeIcons,
+  fontAwesomeIconDefinitions,
+  isFontAwesomeIcon,
+  normalizeFontAwesomeIcon,
+} from './fontawesome'
+
+describe('Font Awesome icon definitions', () => {
+  it('normalizes canonical and prefixed icon values', () => {
+    expect(normalizeFontAwesomeIcon('fa-code')).toBe('fa-solid fa-code')
+    expect(normalizeFontAwesomeIcon('fas fa-code')).toBe('fa-solid fa-code')
+    expect(normalizeFontAwesomeIcon('fa-brands fa-github')).toBe('fa-brands fa-github')
+  })
+
+  it('rejects unknown icons and mismatched styles', () => {
+    expect(isFontAwesomeIcon('fa-missing')).toBe(false)
+    expect(isFontAwesomeIcon('fa-brands fa-code')).toBe(false)
+  })
+
+  it('keeps accepted values derived from the supported icon definitions', () => {
+    expect(fontAwesomeIconDefinitions.some((definition) => definition.canonical === 'fa-github')).toBe(true)
+    expect(acceptedFontAwesomeIcons).toContain('fa-code')
+    expect(acceptedFontAwesomeIcons).toContain('fa-brands fa-github')
+  })
+})

--- a/shared/src/fontawesome.ts
+++ b/shared/src/fontawesome.ts
@@ -1,0 +1,103 @@
+export type FontAwesomeIconStyle = 'solid' | 'brands'
+
+export interface FontAwesomeIconDefinition {
+  canonical: string
+  label: string
+  style: FontAwesomeIconStyle
+}
+
+export const fontAwesomeIconDefinitions = [
+  { canonical: 'fa-arrow-down', label: 'Arrow Down', style: 'solid' },
+  { canonical: 'fa-arrow-left', label: 'Arrow Left', style: 'solid' },
+  { canonical: 'fa-arrow-right', label: 'Arrow Right', style: 'solid' },
+  { canonical: 'fa-arrow-up', label: 'Arrow Up', style: 'solid' },
+  { canonical: 'fa-book', label: 'Book', style: 'solid' },
+  { canonical: 'fa-bug', label: 'Bug', style: 'solid' },
+  { canonical: 'fa-bullhorn', label: 'Bullhorn', style: 'solid' },
+  { canonical: 'fa-bullseye', label: 'Bullseye', style: 'solid' },
+  { canonical: 'fa-chart-line', label: 'Chart Line', style: 'solid' },
+  { canonical: 'fa-check', label: 'Check', style: 'solid' },
+  { canonical: 'fa-check-circle', label: 'Check Circle', style: 'solid' },
+  { canonical: 'fa-chevron-right', label: 'Chevron Right', style: 'solid' },
+  { canonical: 'fa-code', label: 'Code', style: 'solid' },
+  { canonical: 'fa-code-branch', label: 'Code Branch', style: 'solid' },
+  { canonical: 'fa-external-link-alt', label: 'External Link Alt', style: 'solid' },
+  { canonical: 'fa-flask', label: 'Flask', style: 'solid' },
+  { canonical: 'fa-globe', label: 'Globe', style: 'solid' },
+  { canonical: 'fa-heart', label: 'Heart', style: 'solid' },
+  { canonical: 'fa-lock', label: 'Lock', style: 'solid' },
+  { canonical: 'fa-microphone-alt', label: 'Microphone Alt', style: 'solid' },
+  { canonical: 'fa-podcast', label: 'Podcast', style: 'solid' },
+  { canonical: 'fa-quote-left', label: 'Quote Left', style: 'solid' },
+  { canonical: 'fa-rss', label: 'RSS', style: 'solid' },
+  { canonical: 'fa-shield-alt', label: 'Shield Alt', style: 'solid' },
+  { canonical: 'fa-shield-halved', label: 'Shield Halved', style: 'solid' },
+  { canonical: 'fa-star', label: 'Star', style: 'solid' },
+  { canonical: 'fa-tag', label: 'Tag', style: 'solid' },
+  { canonical: 'fa-user-astronaut', label: 'User Astronaut', style: 'solid' },
+  { canonical: 'fa-user-ninja', label: 'User Ninja', style: 'solid' },
+  { canonical: 'fa-user-plus', label: 'User Plus', style: 'solid' },
+  { canonical: 'fa-user-secret', label: 'User Secret', style: 'solid' },
+  { canonical: 'fa-users', label: 'Users', style: 'solid' },
+  { canonical: 'fa-wrench', label: 'Wrench', style: 'solid' },
+  { canonical: 'fa-github', label: 'GitHub', style: 'brands' },
+] as const satisfies readonly FontAwesomeIconDefinition[]
+
+export type SupportedFontAwesomeIcon = (typeof fontAwesomeIconDefinitions)[number]['canonical']
+export type AcceptedFontAwesomeIcon =
+  | SupportedFontAwesomeIcon
+  | `fa-solid ${SupportedFontAwesomeIcon}`
+  | `fas ${SupportedFontAwesomeIcon}`
+  | `fa-brands ${SupportedFontAwesomeIcon}`
+  | `fab ${SupportedFontAwesomeIcon}`
+
+const solidPrefixes = new Set(['fa-solid', 'fas'])
+const brandPrefixes = new Set(['fa-brands', 'fab'])
+const definitionByCanonical = new Map(
+  fontAwesomeIconDefinitions.map((definition) => [definition.canonical, definition]),
+)
+
+export const acceptedFontAwesomeIcons: readonly string[] = fontAwesomeIconDefinitions.flatMap((definition) => {
+  const prefixes = definition.style === 'brands' ? ['fa-brands', 'fab'] : ['fa-solid', 'fas']
+
+  return [
+    definition.canonical,
+    ...prefixes.map((prefix) => `${prefix} ${definition.canonical}`),
+  ]
+})
+
+export function normalizeFontAwesomeIcon(value: string): string | undefined {
+  const parts = value.trim().split(/\s+/)
+
+  if (parts.length === 1) {
+    const [icon] = parts
+    if (!icon) return undefined
+
+    const definition = definitionByCanonical.get(icon as SupportedFontAwesomeIcon)
+    if (!definition) return undefined
+
+    return `${definition.style === 'brands' ? 'fa-brands' : 'fa-solid'} ${definition.canonical}`
+  }
+
+  if (parts.length !== 2) return undefined
+
+  const [prefix, icon] = parts
+  if (!prefix || !icon) return undefined
+
+  const definition = definitionByCanonical.get(icon as SupportedFontAwesomeIcon)
+  if (!definition) return undefined
+
+  const prefixStyle = brandPrefixes.has(prefix)
+    ? 'brands'
+    : solidPrefixes.has(prefix)
+      ? 'solid'
+      : undefined
+
+  if (prefixStyle !== definition.style) return undefined
+
+  return `${definition.style === 'brands' ? 'fa-brands' : 'fa-solid'} ${definition.canonical}`
+}
+
+export function isFontAwesomeIcon(value: string): boolean {
+  return normalizeFontAwesomeIcon(value) !== undefined
+}

--- a/shared/src/json-schema.spec.ts
+++ b/shared/src/json-schema.spec.ts
@@ -7,6 +7,7 @@ import { parse } from 'yaml'
 import { describe, expect, it } from 'vitest'
 
 import { ContentValidator } from './content-validator'
+import { acceptedFontAwesomeIcons } from './fontawesome'
 import { slideSpecSchemaUrls } from './json-schema-urls'
 
 const repoRoot = resolve(fileURLToPath(new URL('.', import.meta.url)), '..', '..')
@@ -222,5 +223,12 @@ describe('public JSON Schemas', () => {
       true,
       true,
     ])
+  })
+
+  it('keeps the public Font Awesome icon schema aligned with runtime validation', async () => {
+    const definitions = JSON.parse(await readFile(resolve(publicSchemaRoot, 'schema/defs.schema.json'), 'utf8'))
+    const fontAwesomeIconEnum = definitions.$defs.fontAwesomeIcon.enum
+
+    expect(fontAwesomeIconEnum).toEqual(acceptedFontAwesomeIcons)
   })
 })

--- a/shared/src/templates/validation.spec.ts
+++ b/shared/src/templates/validation.spec.ts
@@ -14,8 +14,11 @@ describe('template validation', () => {
           image_alt: 'Shield icon',
         },
       },
-      agenda: { title: 'Agenda', content: {} },
-      'section-list-grid': { title: 'Sections', content: { sections: [{ title: 'One', bullets: ['A'] }] } },
+      agenda: { title: 'Agenda', content: { card_arrow_fa_icon: 'fa-chevron-right' } },
+      'section-list-grid': {
+        title: 'Sections',
+        content: { sections: [{ title: 'One', bullets: ['A'], fa_icon: 'fa-star' }] },
+      },
       timeline: {
         title: 'Timeline',
         content: {
@@ -23,6 +26,9 @@ describe('template validation', () => {
           footer_link_label: 'All releases',
           empty_state_title: 'No releases',
           empty_state_message: 'Nothing yet',
+          latest_release_fa_icon: 'fa-tag',
+          release_fa_icon: 'fa-code-branch',
+          footer_link_fa_icon: 'fa-brands fa-github',
           featured_release_ids: ['v1'],
         },
       },
@@ -33,6 +39,10 @@ describe('template validation', () => {
           deliverables_heading: 'Deliverables',
           focus_areas_heading: 'Focus',
           footer_link_label: 'Roadmap',
+          item_fa_icon: 'fa-chevron-right',
+          focus_areas_fa_icon: 'fa-bullseye',
+          theme_fa_icon: 'fa-check',
+          footer_link_fa_icon: 'fa-github',
           stages: {
             completed: { label: 'Done', summary: 'Completed work' },
             'in-progress': { label: 'Now', summary: 'Current work' },
@@ -49,7 +59,10 @@ describe('template validation', () => {
           banner_prefix: 'Thanks',
           contributors_link_label: 'Contributors',
           banner_suffix: 'team',
-          spotlight: [{ login: 'octocat', summary: 'Shipped a fix' }],
+          github_fa_icon: 'fa-github',
+          quote_fa_icon: 'fa-quote-left',
+          banner_fa_icon: 'fa-heart',
+          spotlight: [{ login: 'octocat', summary: 'Shipped a fix', fa_icon: 'fa-user-astronaut' }],
         },
       },
       'metrics-and-links': {
@@ -59,8 +72,20 @@ describe('template validation', () => {
           stats_heading: 'Stats',
           show_deltas: true,
           trend_suffix: 'from last period',
+          section_heading_fa_icon: 'fa-bullhorn',
+          stats_heading_fa_icon: 'fa-chart-line',
+          stat_fa_icons: ['fa-star'],
+          trend_up_fa_icon: 'fa-arrow-up',
+          trend_down_fa_icon: 'fa-arrow-down',
           stat_keys: ['stars'],
-          mentions: [{ type: 'release', title: 'v1', url_label: 'Read', url: 'https://example.test' }],
+          mentions: [{
+            type: 'release',
+            title: 'v1',
+            url_label: 'Read',
+            url: 'https://example.test',
+            fa_icon: 'fa-rss',
+            link_fa_icon: 'fa-external-link-alt',
+          }],
         },
       },
       'image-and-bullets': {
@@ -79,10 +104,28 @@ describe('template validation', () => {
         title: 'Actions',
         content: {
           footer_text: 'Get involved',
-          cards: [{ title: 'Try it', description: 'Run the CLI', url_label: 'Docs', url: 'https://example.test' }],
+          footer_fa_icon: 'fa-github',
+          footer_link_fa_icon: 'fa-code',
+          cards: [{
+            title: 'Try it',
+            description: 'Run the CLI',
+            url_label: 'Docs',
+            url: 'https://example.test',
+            fa_icon: 'fa-bug',
+            link_fa_icon: 'fa-arrow-right',
+          }],
         },
       },
-      closing: { content: { heading: 'Thanks', message: 'Questions?', quote: 'Ship clear slides.' } },
+      closing: {
+        content: {
+          heading: 'Thanks',
+          message: 'Questions?',
+          quote: 'Ship clear slides.',
+          repository_fa_icon: 'fa-github',
+          docs_fa_icon: 'fa-book',
+          community_fa_icon: 'fa-shield-alt',
+        },
+      },
     } as const
 
     for (const [templateId, slide] of Object.entries(validSlides)) {
@@ -121,5 +164,8 @@ describe('template validation', () => {
     expect(() =>
       validateTemplateSlide('image-and-bullets', { title: 'Highlights', content: { bullets: [] } }, 'slides[6]'),
     ).toThrow('slides[6].content.bullets must include at least one item.')
+    expect(() =>
+      validateTemplateSlide('agenda', { title: 'Agenda', content: { card_arrow_fa_icon: 'fa-nope' } }, 'slides[7]'),
+    ).toThrow('slides[7].content.card_arrow_fa_icon must be a supported Font Awesome icon.')
   })
 })

--- a/shared/src/templates/validation.ts
+++ b/shared/src/templates/validation.ts
@@ -3,6 +3,7 @@ import {
   assertNoUnexpectedKeys,
   assertNonBlankString,
   assertOptionalBoolean,
+  assertOptionalFontAwesomeIcon,
   assertOptionalString,
   assertStringArray,
   isRecord,
@@ -38,22 +39,29 @@ export type SlideTemplateValidator = (slide: SlideRecord, path: string) => void
 
 function assertContentSection(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['title', 'bullets', 'fa_icon'], path)
   assertNonBlankString(value.title, `${path}.title`)
   assertStringArray(value.bullets, `${path}.bullets`)
+  assertOptionalFontAwesomeIcon(value.fa_icon, `${path}.fa_icon`)
 }
 
 function assertSpotlightEntry(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['login', 'summary', 'fa_icon'], path)
   assertNonBlankString(value.login, `${path}.login`)
   assertNonBlankString(value.summary, `${path}.summary`)
+  assertOptionalFontAwesomeIcon(value.fa_icon, `${path}.fa_icon`)
 }
 
 function assertContributionCard(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['title', 'description', 'url_label', 'url', 'fa_icon', 'link_fa_icon'], path)
   assertNonBlankString(value.title, `${path}.title`)
   assertNonBlankString(value.description, `${path}.description`)
   assertNonBlankString(value.url_label, `${path}.url_label`)
   assertNonBlankString(value.url, `${path}.url`)
+  assertOptionalFontAwesomeIcon(value.fa_icon, `${path}.fa_icon`)
+  assertOptionalFontAwesomeIcon(value.link_fa_icon, `${path}.link_fa_icon`)
 }
 
 function assertImageAndBulletsImage(value: unknown, path: string): void {
@@ -62,6 +70,13 @@ function assertImageAndBulletsImage(value: unknown, path: string): void {
   assertNonBlankString(value.src, `${path}.src`)
   assertOptionalString(value.alt, `${path}.alt`)
   assertOptionalString(value.description, `${path}.description`)
+}
+
+function assertOptionalFontAwesomeIconArray(value: unknown, path: string): void {
+  if (value === undefined) return
+
+  assert(Array.isArray(value), `${path} must be an array.`)
+  ;(value as unknown[]).forEach((icon, index) => assertOptionalFontAwesomeIcon(icon, `${path}[${index}]`))
 }
 
 const heroValidator: SlideTemplateValidator = (slide, path) => {
@@ -92,6 +107,11 @@ const sectionTitleValidator: SlideTemplateValidator = (slide, path) => {
 
 const agendaValidator: SlideTemplateValidator = (slide, path) => {
   assertNonBlankString(slide.title, `${path}.title`)
+  if (slide.content !== undefined) {
+    const content = slide.content as Record<string, unknown>
+    assertNoUnexpectedKeys(content, ['card_arrow_fa_icon'], `${path}.content`)
+    assertOptionalFontAwesomeIcon(content.card_arrow_fa_icon, `${path}.content.card_arrow_fa_icon`)
+  }
 }
 
 const sectionListGridValidator: SlideTemplateValidator = (slide, path) => {
@@ -108,7 +128,16 @@ const timelineValidator: SlideTemplateValidator = (slide, path) => {
   const content = slide.content as Record<string, unknown>
   assertNoUnexpectedKeys(
     content,
-    ['latest_badge_label', 'footer_link_label', 'empty_state_title', 'empty_state_message', 'featured_release_ids'],
+    [
+      'latest_badge_label',
+      'footer_link_label',
+      'empty_state_title',
+      'empty_state_message',
+      'featured_release_ids',
+      'latest_release_fa_icon',
+      'release_fa_icon',
+      'footer_link_fa_icon',
+    ],
     `${path}.content`,
   )
   assertOptionalString(content.latest_badge_label, `${path}.content.latest_badge_label`)
@@ -116,6 +145,9 @@ const timelineValidator: SlideTemplateValidator = (slide, path) => {
   assertOptionalString(content.empty_state_title, `${path}.content.empty_state_title`)
   assertOptionalString(content.empty_state_message, `${path}.content.empty_state_message`)
   assertStringArray(content.featured_release_ids, `${path}.content.featured_release_ids`)
+  assertOptionalFontAwesomeIcon(content.latest_release_fa_icon, `${path}.content.latest_release_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.release_fa_icon, `${path}.content.release_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.footer_link_fa_icon, `${path}.content.footer_link_fa_icon`)
 }
 
 const progressTimelineValidator: SlideTemplateValidator = (slide, path) => {
@@ -123,7 +155,19 @@ const progressTimelineValidator: SlideTemplateValidator = (slide, path) => {
   const content = slide.content as Record<string, unknown>
   assertNoUnexpectedKeys(
     content,
-    ['stage', 'deliverables_heading', 'focus_areas_heading', 'footer_link_label', 'stages', 'items', 'themes'],
+    [
+      'stage',
+      'deliverables_heading',
+      'focus_areas_heading',
+      'footer_link_label',
+      'stages',
+      'items',
+      'themes',
+      'item_fa_icon',
+      'focus_areas_fa_icon',
+      'theme_fa_icon',
+      'footer_link_fa_icon',
+    ],
     `${path}.content`,
   )
   assertNonBlankString(content.stage, `${path}.content.stage`)
@@ -134,6 +178,10 @@ const progressTimelineValidator: SlideTemplateValidator = (slide, path) => {
   assertOptionalString(content.deliverables_heading, `${path}.content.deliverables_heading`)
   assertOptionalString(content.focus_areas_heading, `${path}.content.focus_areas_heading`)
   assertOptionalString(content.footer_link_label, `${path}.content.footer_link_label`)
+  assertOptionalFontAwesomeIcon(content.item_fa_icon, `${path}.content.item_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.focus_areas_fa_icon, `${path}.content.focus_areas_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.theme_fa_icon, `${path}.content.theme_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.footer_link_fa_icon, `${path}.content.footer_link_fa_icon`)
   assert(isRecord(content.stages), `${path}.content.stages must be an object.`)
   for (const key of roadmapStageKeys) {
     assertRoadmapStageContent(
@@ -150,12 +198,23 @@ const peopleValidator: SlideTemplateValidator = (slide, path) => {
   const content = slide.content as Record<string, unknown>
   assertNoUnexpectedKeys(
     content,
-    ['banner_prefix', 'contributors_link_label', 'banner_suffix', 'spotlight'],
+    [
+      'banner_prefix',
+      'contributors_link_label',
+      'banner_suffix',
+      'spotlight',
+      'github_fa_icon',
+      'quote_fa_icon',
+      'banner_fa_icon',
+    ],
     `${path}.content`,
   )
   assertOptionalString(content.banner_prefix, `${path}.content.banner_prefix`)
   assertOptionalString(content.contributors_link_label, `${path}.content.contributors_link_label`)
   assertOptionalString(content.banner_suffix, `${path}.content.banner_suffix`)
+  assertOptionalFontAwesomeIcon(content.github_fa_icon, `${path}.content.github_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.quote_fa_icon, `${path}.content.quote_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.banner_fa_icon, `${path}.content.banner_fa_icon`)
   assert(Array.isArray(content.spotlight), `${path}.content.spotlight must be an array.`)
   ;(content.spotlight as unknown[]).forEach((entry, index) =>
     assertSpotlightEntry(entry, `${path}.content.spotlight[${index}]`))
@@ -166,22 +225,42 @@ const metricsAndLinksValidator: SlideTemplateValidator = (slide, path) => {
   const content = slide.content as Record<string, unknown>
   assertNoUnexpectedKeys(
     content,
-    ['section_heading', 'stats_heading', 'show_deltas', 'trend_suffix', 'stat_keys', 'mentions'],
+    [
+      'section_heading',
+      'stats_heading',
+      'show_deltas',
+      'trend_suffix',
+      'stat_keys',
+      'mentions',
+      'section_heading_fa_icon',
+      'stats_heading_fa_icon',
+      'stat_fa_icons',
+      'trend_up_fa_icon',
+      'trend_down_fa_icon',
+    ],
     `${path}.content`,
   )
   assertOptionalString(content.section_heading, `${path}.content.section_heading`)
   assertOptionalString(content.stats_heading, `${path}.content.stats_heading`)
   assertOptionalBoolean(content.show_deltas, `${path}.content.show_deltas`)
   assertOptionalString(content.trend_suffix, `${path}.content.trend_suffix`)
+  assertOptionalFontAwesomeIcon(content.section_heading_fa_icon, `${path}.content.section_heading_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.stats_heading_fa_icon, `${path}.content.stats_heading_fa_icon`)
+  assertOptionalFontAwesomeIconArray(content.stat_fa_icons, `${path}.content.stat_fa_icons`)
+  assertOptionalFontAwesomeIcon(content.trend_up_fa_icon, `${path}.content.trend_up_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.trend_down_fa_icon, `${path}.content.trend_down_fa_icon`)
   assertStringArray(content.stat_keys, `${path}.content.stat_keys`)
   assert(Array.isArray(content.mentions), `${path}.content.mentions must be an array.`)
   ;(content.mentions as unknown[]).forEach((mention, index) => {
     const mentionPath = `${path}.content.mentions[${index}]`
     assert(isRecord(mention), `${mentionPath} must be an object.`)
+    assertNoUnexpectedKeys(mention, ['type', 'title', 'url_label', 'url', 'fa_icon', 'link_fa_icon'], mentionPath)
     assertNonBlankString(mention.type, `${mentionPath}.type`)
     assertNonBlankString(mention.title, `${mentionPath}.title`)
     assertOptionalString(mention.url_label, `${mentionPath}.url_label`)
     assertOptionalString(mention.url, `${mentionPath}.url`)
+    assertOptionalFontAwesomeIcon(mention.fa_icon, `${mentionPath}.fa_icon`)
+    assertOptionalFontAwesomeIcon(mention.link_fa_icon, `${mentionPath}.link_fa_icon`)
     assert(
       (mention.url === undefined && mention.url_label === undefined)
         || (mention.url !== undefined && mention.url_label !== undefined),
@@ -193,8 +272,10 @@ const metricsAndLinksValidator: SlideTemplateValidator = (slide, path) => {
 const actionCardsValidator: SlideTemplateValidator = (slide, path) => {
   assertNonBlankString(slide.title, `${path}.title`)
   const content = slide.content as Record<string, unknown>
-  assertNoUnexpectedKeys(content, ['footer_text', 'cards'], `${path}.content`)
+  assertNoUnexpectedKeys(content, ['footer_text', 'cards', 'footer_fa_icon', 'footer_link_fa_icon'], `${path}.content`)
   assertOptionalString(content.footer_text, `${path}.content.footer_text`)
+  assertOptionalFontAwesomeIcon(content.footer_fa_icon, `${path}.content.footer_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.footer_link_fa_icon, `${path}.content.footer_link_fa_icon`)
   assert(Array.isArray(content.cards), `${path}.content.cards must be an array.`)
   ;(content.cards as unknown[]).forEach((card, index) =>
     assertContributionCard(card, `${path}.content.cards[${index}]`))
@@ -224,10 +305,17 @@ const imageAndBulletsValidator: SlideTemplateValidator = (slide, path) => {
 
 const closingValidator: SlideTemplateValidator = (slide, path) => {
   const content = slide.content as Record<string, unknown>
-  assertNoUnexpectedKeys(content, ['heading', 'message', 'quote'], `${path}.content`)
+  assertNoUnexpectedKeys(
+    content,
+    ['heading', 'message', 'quote', 'repository_fa_icon', 'docs_fa_icon', 'community_fa_icon'],
+    `${path}.content`,
+  )
   assertNonBlankString(content.heading, `${path}.content.heading`)
   assertNonBlankString(content.message, `${path}.content.message`)
   assertOptionalString(content.quote, `${path}.content.quote`)
+  assertOptionalFontAwesomeIcon(content.repository_fa_icon, `${path}.content.repository_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.docs_fa_icon, `${path}.content.docs_fa_icon`)
+  assertOptionalFontAwesomeIcon(content.community_fa_icon, `${path}.content.community_fa_icon`)
 }
 
 export const slideTemplateValidators: Record<SlideTemplateId, SlideTemplateValidator> = {

--- a/shared/src/validation/assertions.ts
+++ b/shared/src/validation/assertions.ts
@@ -1,4 +1,5 @@
 import { SLIDE_SPEC_SCHEMA_VERSION } from '../schema-version'
+import { isFontAwesomeIcon } from '../fontawesome'
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -22,6 +23,17 @@ export function assertNonBlankString(value: unknown, path: string): asserts valu
 export function assertOptionalString(value: unknown, path: string): void {
   if (value !== undefined) {
     assertNonBlankString(value, path)
+  }
+}
+
+export function assertFontAwesomeIcon(value: unknown, path: string): asserts value is string {
+  assertNonBlankString(value, path)
+  assert(isFontAwesomeIcon(value), `${path} must be a supported Font Awesome icon.`)
+}
+
+export function assertOptionalFontAwesomeIcon(value: unknown, path: string): void {
+  if (value !== undefined) {
+    assertFontAwesomeIcon(value, path)
   }
 }
 

--- a/slides/content/presentations/2025-open-source-example/presentation.yaml
+++ b/slides/content/presentations/2025-open-source-example/presentation.yaml
@@ -17,6 +17,8 @@ presentation:
       enabled: true
       title: Agenda
       subtitle: What this update covers
+      content:
+        card_arrow_fa_icon: fa-arrow-right
     - template: section-list-grid
       enabled: true
       title: What shipped
@@ -24,16 +26,19 @@ presentation:
       content:
         sections:
           - title: Plugin system
+            fa_icon: fa-code-branch
             bullets:
               - Local plugins resolve from the project directory
               - Registry plugins install from the public catalog
               - Lifecycle hooks for init, build, and deploy phases
           - title: Error messages
+            fa_icon: fa-bug
             bullets:
               - Structured output with error codes and fix suggestions
               - Links to relevant documentation in every error
               - Machine-readable JSON output for CI pipelines
           - title: Shell completions
+            fa_icon: fa-wrench
             bullets:
               - Auto-generated completions for bash, zsh, and fish
               - Dynamic completions for project-specific commands
@@ -45,6 +50,8 @@ presentation:
       content:
         latest_badge_label: Latest
         footer_link_label: All releases on GitHub
+        latest_release_fa_icon: fa-tag
+        release_fa_icon: fa-code-branch
         featured_release_ids:
           - v3-2-0
           - v3-1-0
@@ -64,6 +71,8 @@ presentation:
         deliverables_heading: Shipped
         focus_areas_heading: Themes
         footer_link_label: View full roadmap
+        item_fa_icon: fa-check
+        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -94,8 +103,10 @@ presentation:
         banner_prefix: Thanks to all
         contributors_link_label: contributors
         banner_suffix: who helped shape this release.
+        quote_fa_icon: fa-quote-left
         spotlight:
           - login: sarah-plugins
+            fa_icon: fa-user-astronaut
             summary: Designed and implemented the plugin resolution system from scratch.
           - login: kai-errors
             summary: Rewrote the error pipeline to include structured codes and fix suggestions.
@@ -110,6 +121,11 @@ presentation:
         stats_heading: This quarter
         trend_suffix: vs last quarter
         show_deltas: true
+        stat_fa_icons:
+          - fa-star
+          - fa-check-circle
+          - fa-code-branch
+          - fa-user-plus
         stat_keys:
           - stars
           - issues_closed
@@ -117,6 +133,7 @@ presentation:
           - new_contributors
         mentions:
           - type: Blog post
+            fa_icon: fa-rss
             title: How we built the Vortex plugin system
             url_label: Read on the blog
             url: https://vortex-cli.example.com/blog/plugin-system
@@ -146,14 +163,17 @@ presentation:
         footer_text: Every contribution matters, no matter the size.
         cards:
           - title: Write a plugin
+            fa_icon: fa-code
             description: Build a plugin and publish it to the registry. The plugin guide has templates to get started.
             url_label: Plugin guide
             url: https://vortex-cli.example.com/docs/plugins
           - title: Improve docs
+            fa_icon: fa-book
             description: Help us write better guides, fix typos, or add examples for common workflows.
             url_label: Docs backlog
             url: https://github.com/example/vortex-cli/issues?q=label%3Adocs
           - title: Report bugs
+            fa_icon: fa-bug
             description: Found something broken? File an issue with reproduction steps and we will prioritize it.
             url_label: Open an issue
             url: https://github.com/example/vortex-cli/issues/new
@@ -163,3 +183,6 @@ presentation:
         heading: Thank you
         message: Vortex CLI is built by its community. Every issue, PR, and plugin makes it better for everyone.
         quote: Ship tools, not tickets.
+        repository_fa_icon: fa-github
+        docs_fa_icon: fa-book
+        community_fa_icon: fa-users

--- a/slides/public/schema/defs.schema.json
+++ b/slides/public/schema/defs.schema.json
@@ -17,6 +17,120 @@
         "$ref": "#/$defs/nonBlankString"
       }
     },
+    "fontAwesomeIcon": {
+      "type": "string",
+      "description": "Supported Font Awesome icon. See https://docs.slide-spec.dev/reference/fontawesome.",
+      "enum": [
+        "fa-arrow-down",
+        "fa-solid fa-arrow-down",
+        "fas fa-arrow-down",
+        "fa-arrow-left",
+        "fa-solid fa-arrow-left",
+        "fas fa-arrow-left",
+        "fa-arrow-right",
+        "fa-solid fa-arrow-right",
+        "fas fa-arrow-right",
+        "fa-arrow-up",
+        "fa-solid fa-arrow-up",
+        "fas fa-arrow-up",
+        "fa-book",
+        "fa-solid fa-book",
+        "fas fa-book",
+        "fa-bug",
+        "fa-solid fa-bug",
+        "fas fa-bug",
+        "fa-bullhorn",
+        "fa-solid fa-bullhorn",
+        "fas fa-bullhorn",
+        "fa-bullseye",
+        "fa-solid fa-bullseye",
+        "fas fa-bullseye",
+        "fa-chart-line",
+        "fa-solid fa-chart-line",
+        "fas fa-chart-line",
+        "fa-check",
+        "fa-solid fa-check",
+        "fas fa-check",
+        "fa-check-circle",
+        "fa-solid fa-check-circle",
+        "fas fa-check-circle",
+        "fa-chevron-right",
+        "fa-solid fa-chevron-right",
+        "fas fa-chevron-right",
+        "fa-code",
+        "fa-solid fa-code",
+        "fas fa-code",
+        "fa-code-branch",
+        "fa-solid fa-code-branch",
+        "fas fa-code-branch",
+        "fa-external-link-alt",
+        "fa-solid fa-external-link-alt",
+        "fas fa-external-link-alt",
+        "fa-flask",
+        "fa-solid fa-flask",
+        "fas fa-flask",
+        "fa-globe",
+        "fa-solid fa-globe",
+        "fas fa-globe",
+        "fa-heart",
+        "fa-solid fa-heart",
+        "fas fa-heart",
+        "fa-lock",
+        "fa-solid fa-lock",
+        "fas fa-lock",
+        "fa-microphone-alt",
+        "fa-solid fa-microphone-alt",
+        "fas fa-microphone-alt",
+        "fa-podcast",
+        "fa-solid fa-podcast",
+        "fas fa-podcast",
+        "fa-quote-left",
+        "fa-solid fa-quote-left",
+        "fas fa-quote-left",
+        "fa-rss",
+        "fa-solid fa-rss",
+        "fas fa-rss",
+        "fa-shield-alt",
+        "fa-solid fa-shield-alt",
+        "fas fa-shield-alt",
+        "fa-shield-halved",
+        "fa-solid fa-shield-halved",
+        "fas fa-shield-halved",
+        "fa-star",
+        "fa-solid fa-star",
+        "fas fa-star",
+        "fa-tag",
+        "fa-solid fa-tag",
+        "fas fa-tag",
+        "fa-user-astronaut",
+        "fa-solid fa-user-astronaut",
+        "fas fa-user-astronaut",
+        "fa-user-ninja",
+        "fa-solid fa-user-ninja",
+        "fas fa-user-ninja",
+        "fa-user-plus",
+        "fa-solid fa-user-plus",
+        "fas fa-user-plus",
+        "fa-user-secret",
+        "fa-solid fa-user-secret",
+        "fas fa-user-secret",
+        "fa-users",
+        "fa-solid fa-users",
+        "fas fa-users",
+        "fa-wrench",
+        "fa-solid fa-wrench",
+        "fas fa-wrench",
+        "fa-github",
+        "fa-brands fa-github",
+        "fab fa-github"
+      ]
+    },
+    "fontAwesomeIconArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/fontAwesomeIcon"
+      }
+    },
     "link": {
       "type": "object",
       "required": ["label", "url"],
@@ -104,7 +218,8 @@
       "additionalProperties": false,
       "properties": {
         "title": { "$ref": "#/$defs/nonBlankString" },
-        "bullets": { "$ref": "#/$defs/stringArray" }
+        "bullets": { "$ref": "#/$defs/stringArray" },
+        "fa_icon": { "$ref": "#/$defs/fontAwesomeIcon" }
       }
     },
     "roadmapStage": {
@@ -131,7 +246,8 @@
       "additionalProperties": false,
       "properties": {
         "login": { "$ref": "#/$defs/nonBlankString" },
-        "summary": { "$ref": "#/$defs/nonBlankString" }
+        "summary": { "$ref": "#/$defs/nonBlankString" },
+        "fa_icon": { "$ref": "#/$defs/fontAwesomeIcon" }
       }
     },
     "communityMention": {
@@ -146,7 +262,9 @@
         "type": { "$ref": "#/$defs/nonBlankString" },
         "title": { "$ref": "#/$defs/nonBlankString" },
         "url_label": { "$ref": "#/$defs/nonBlankString" },
-        "url": { "$ref": "#/$defs/nonBlankString" }
+        "url": { "$ref": "#/$defs/nonBlankString" },
+        "fa_icon": { "$ref": "#/$defs/fontAwesomeIcon" },
+        "link_fa_icon": { "$ref": "#/$defs/fontAwesomeIcon" }
       }
     },
     "contributionCard": {
@@ -157,7 +275,9 @@
         "title": { "$ref": "#/$defs/nonBlankString" },
         "description": { "$ref": "#/$defs/nonBlankString" },
         "url_label": { "$ref": "#/$defs/nonBlankString" },
-        "url": { "$ref": "#/$defs/nonBlankString" }
+        "url": { "$ref": "#/$defs/nonBlankString" },
+        "fa_icon": { "$ref": "#/$defs/fontAwesomeIcon" },
+        "link_fa_icon": { "$ref": "#/$defs/fontAwesomeIcon" }
       }
     }
   }

--- a/slides/public/schema/presentation.schema.json
+++ b/slides/public/schema/presentation.schema.json
@@ -100,7 +100,10 @@
             "template": { "const": "agenda" },
             "content": {
               "type": "object",
-              "additionalProperties": false
+              "additionalProperties": false,
+              "properties": {
+                "card_arrow_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" }
+              }
             }
           }
         }
@@ -172,6 +175,9 @@
                 "footer_link_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "empty_state_title": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "empty_state_message": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "latest_release_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "release_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "footer_link_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
                 "featured_release_ids": { "$ref": "defs.schema.json#/$defs/stringArray" }
               }
             }
@@ -196,6 +202,10 @@
                 "deliverables_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "focus_areas_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "footer_link_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "item_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "focus_areas_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "theme_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "footer_link_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
                 "stages": {
                   "type": "object",
                   "required": ["completed", "in-progress", "planned", "future"],
@@ -234,6 +244,9 @@
                 "banner_prefix": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "contributors_link_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "banner_suffix": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "github_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "quote_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "banner_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
                 "spotlight": {
                   "type": "array",
                   "items": { "$ref": "defs.schema.json#/$defs/spotlightEntry" }
@@ -261,6 +274,11 @@
                 "stats_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "show_deltas": { "type": "boolean" },
                 "trend_suffix": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "section_heading_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "stats_heading_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "stat_fa_icons": { "$ref": "defs.schema.json#/$defs/fontAwesomeIconArray" },
+                "trend_up_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "trend_down_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
                 "stat_keys": { "$ref": "defs.schema.json#/$defs/stringArray" },
                 "mentions": {
                   "type": "array",
@@ -286,6 +304,8 @@
               "additionalProperties": false,
               "properties": {
                 "footer_text": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "footer_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "footer_link_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
                 "cards": {
                   "type": "array",
                   "items": { "$ref": "defs.schema.json#/$defs/contributionCard" }
@@ -351,7 +371,10 @@
               "properties": {
                 "heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "message": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
-                "quote": { "$ref": "defs.schema.json#/$defs/nonBlankString" }
+                "quote": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "repository_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "docs_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
+                "community_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" }
               }
             }
           }

--- a/slides/public/schema/site.schema.json
+++ b/slides/public/schema/site.schema.json
@@ -94,7 +94,7 @@
       ],
       "properties": {
         "label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
-        "fa_icon": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+        "fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
         "icon_position": { "enum": ["before", "after"] }
       }
     },


### PR DESCRIPTION
## What

Allows users to define the font-awesome icons used on any slide with icons

## Related issue

<!-- Link the issue this PR addresses. An issue is required before opening a PR. -->

Closes #158 


## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [x] Documentation
- [ ] Other (describe below)

<!-- If selecting "Other", please describe the type of change -->

## Breaking changes

<!-- Does this PR introduce a breaking change? Slide Spec follows semver - breaking changes must be clearly documented. -->

- [ ] Yes (describe below)
- [x] No

New field, but with defaults so backward compatible.
<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes
