### PR TITLE
progress-timeline supports dynamic stages

### DIFF
--- a/app/src/components/slides/RoadmapSlideView.spec.ts
+++ b/app/src/components/slides/RoadmapSlideView.spec.ts
@@ -63,6 +63,43 @@ describe('RoadmapSlideView', () => {
     expect(wrapper.find('.footer-link').exists()).toBe(false)
   })
 
+  it('renders timeline stages from authored stage keys', () => {
+    const slide = roadmapSlides[0]
+
+    if (!slide || slide.template !== 'progress-timeline') {
+      throw new Error('Expected roadmap slide in fixture data')
+    }
+
+    const wrapper = mount(RoadmapSlideView, {
+      props: {
+        presentation: record.presentation,
+        site: contentRepository.getSiteContent(),
+        slide: {
+          ...slide,
+          content: {
+            ...slide.content,
+            stage: '6-months',
+            stages: {
+              '3-months': { label: '3 Months', summary: 'Stabilize adoption.' },
+              '6-months': { label: '6 Months', summary: 'Expand core workflows.' },
+              '12-months': { label: '12 Months', summary: 'Scale the operating model.' },
+            },
+          },
+        },
+        slideNumber: 4,
+        slideTotal: 12,
+      },
+    })
+
+    const timelineItems = wrapper.findAll('.progress-timeline__item')
+
+    expect(timelineItems).toHaveLength(3)
+    expect(timelineItems[0]?.classes()).toContain('progress-timeline__item--viewed')
+    expect(timelineItems[1]?.classes()).toContain('progress-timeline__item--current')
+    expect(timelineItems[2]?.classes()).toContain('progress-timeline__item--upcoming')
+    expect(wrapper.text()).toContain('6 Months')
+  })
+
   it('omits optional roadmap headings and stage eyebrow when slide-local labels are blank', () => {
     const slide = roadmapSlides[2]
 

--- a/app/src/components/slides/RoadmapSlideView.vue
+++ b/app/src/components/slides/RoadmapSlideView.vue
@@ -12,7 +12,6 @@ import { resolveRoadmapLabels } from '../../content/contentDefaults'
 import type {
   PresentationContent,
   RoadmapSlide,
-  RoadmapStageStatus,
   SiteContent,
 } from '../../types/content'
 
@@ -24,11 +23,11 @@ const props = defineProps<{
   slideTotal: number
 }>()
 
-const stageOrder: RoadmapStageStatus[] = ['completed', 'in-progress', 'planned', 'future']
 const stages = computed(() => props.slide.content.stages)
-const activeStageIndex = computed(() => stageOrder.indexOf(props.slide.content.stage))
+const stageOrder = computed(() => Object.keys(stages.value))
+const activeStageIndex = computed(() => stageOrder.value.indexOf(props.slide.content.stage))
 const timelineStages = computed(() =>
-  stageOrder.map((status, index) => {
+  stageOrder.value.map((status, index) => {
     let progressState: 'viewed' | 'current' | 'upcoming' = 'upcoming'
 
     if (index < activeStageIndex.value) {

--- a/app/src/components/ui/ProgressTimeline.vue
+++ b/app/src/components/ui/ProgressTimeline.vue
@@ -16,7 +16,10 @@ defineProps<{
 <template>
   <div class="progress-timeline">
     <div class="progress-timeline__line"></div>
-    <div class="progress-timeline__items">
+    <div
+      class="progress-timeline__items"
+      :style="{ gridTemplateColumns: `repeat(${items.length}, minmax(0, 1fr))` }"
+    >
       <div
         v-for="item in items"
         :key="item.key"
@@ -49,7 +52,6 @@ defineProps<{
   position: relative;
   z-index: 1;
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1rem;
 }
 

--- a/app/src/templates/validation.spec.ts
+++ b/app/src/templates/validation.spec.ts
@@ -319,6 +319,9 @@ describe('template validation', () => {
       title: 'Roadmap',
       content: {
         stage: 'active',
+        stages: validRoadmapStages,
+        items: [],
+        themes: [],
       },
     },
     people: {
@@ -387,7 +390,7 @@ describe('template validation', () => {
       'section-list-grid': 'slides[section-list-grid].content.sections must be an array.',
       timeline: 'slides[timeline].content.featured_release_ids must be an array.',
       'progress-timeline':
-        'slides[progress-timeline].content.stage must be one of completed, in-progress, planned, or future.',
+        'slides[progress-timeline].content.stage must match one of the keys in slides[progress-timeline].content.stages.',
       people: 'slides[people].content.spotlight[0].summary must be a string.',
       'metrics-and-links':
         'slides[metrics-and-links].content.mentions[0] must provide url and url_label together.',
@@ -426,5 +429,30 @@ describe('template validation', () => {
         'slides[metrics-and-links]',
       ),
     ).toThrow('slides[metrics-and-links].content.show_deltas must be a boolean.')
+  })
+
+  it('accepts progress-timeline slides with three authored stages', () => {
+    const definition = getSlideTemplateDefinition('progress-timeline')
+
+    expect(() =>
+      definition.validate(
+        {
+          template: 'progress-timeline',
+          enabled: true,
+          title: 'Roadmap',
+          content: {
+            stage: '6-months',
+            stages: {
+              '3-months': { label: '3 Months', summary: 'Stabilize adoption.' },
+              '6-months': { label: '6 Months', summary: 'Expand core workflows.' },
+              '12-months': { label: '12 Months', summary: 'Scale the operating model.' },
+            },
+            items: ['Measure adoption'],
+            themes: [{ category: 'Adoption', target: 'Make progress explicit' }],
+          },
+        },
+        'slides[progress-timeline]',
+      ),
+    ).not.toThrow()
   })
 })

--- a/app/src/types/content.ts
+++ b/app/src/types/content.ts
@@ -294,7 +294,7 @@ export interface ContentSection {
   fa_icon?: string
 }
 
-export type RoadmapStageStatus = 'completed' | 'in-progress' | 'planned' | 'future'
+export type RoadmapStageStatus = string
 
 export interface RoadmapTheme {
   category: string

--- a/content/presentations/2026-q1/presentation.yaml
+++ b/content/presentations/2026-q1/presentation.yaml
@@ -88,9 +88,6 @@ presentation:
             label: Planned
             summary: The published roadmap shifts next-step planning toward enterprise readiness, better UX, and automation-friendly
               workflows.
-          future:
-            label: Future
-            summary: Version 3.x remains centered on a more interoperable file format and long-horizon project maturity goals.
         items:
           - Reusable briefing templates landed for roadmap, release, and community updates.
           - Aurora Notes' content manifest gained clearer publication metadata.

--- a/docs/schema/presentation.md
+++ b/docs/schema/presentation.md
@@ -138,7 +138,7 @@ Each `sections[]` entry may also set `fa_icon` to override its badge icon.
 | Field | Required | Notes |
 | --- | --- | --- |
 | `title` | yes | |
-| `content.stage` | yes | `completed`, `in-progress`, `planned`, or `future` |
+| `content.stage` | yes | Must match one key in `content.stages` |
 | `content.deliverables_heading` | | |
 | `content.focus_areas_heading` | | |
 | `content.footer_link_label` | | |
@@ -146,7 +146,7 @@ Each `sections[]` entry may also set `fa_icon` to override its badge icon.
 | `content.focus_areas_fa_icon` | | Defaults to `fa-bullseye` |
 | `content.theme_fa_icon` | | Defaults to `fa-chevron-right` |
 | `content.footer_link_fa_icon` | | Defaults to `fa-github` |
-| `content.stages` | yes | Four stage strip entries |
+| `content.stages` | yes | 2 to 6 stage strip entries, rendered in authored order |
 | `content.items` | yes | Active stage items |
 | `content.themes` | yes | Active stage themes |
 

--- a/docs/templates/progress-timeline.md
+++ b/docs/templates/progress-timeline.md
@@ -1,6 +1,6 @@
 # Progress Timeline
 
-Focuses a single stage. Each slide carries its own stage headings and four stage strip entries in `content`. The progress strip shows all four stages; the detail columns use the slide's own `items` and `themes` for the active stage only.
+Focuses a single stage. Each slide carries its own stage headings and stage strip entries in `content`. The progress strip shows the authored stages in order; the detail columns use the slide's own `items` and `themes` for the active stage only.
 
 <figure class="template-doc-shot">
   <img src="/screenshots/template-progress-timeline-reference.png" alt="Progress timeline slide showing roadmap stages with the active stage expanded" />
@@ -13,10 +13,10 @@ Focuses a single stage. Each slide carries its own stage headings and four stage
 ```yaml
 - template: progress-timeline
   enabled: true
-  title: "Roadmap: Completed"
-  subtitle: Delivered work
+  title: "Roadmap: 6 Months"
+  subtitle: Current roadmap focus
   content:
-    stage: completed
+    stage: 6-months
     deliverables_heading: Key deliverables
     focus_areas_heading: Focus areas
     footer_link_label: View roadmap on GitHub
@@ -25,18 +25,15 @@ Focuses a single stage. Each slide carries its own stage headings and four stage
     theme_fa_icon: fa-chevron-right
     footer_link_fa_icon: fa-github
     stages:
-      completed:
-        label: Completed
-        summary: Work that shipped during this period.
-      in-progress:
-        label: In Progress
-        summary: Active work continuing into the next cycle.
-      planned:
-        label: Planned
-        summary: Scoped for the next cycle.
-      future:
-        label: Future
-        summary: Depends on the current architecture pass.
+      3-months:
+        label: 3 Months
+        summary: Stabilize adoption.
+      6-months:
+        label: 6 Months
+        summary: Expand core workflows.
+      12-months:
+        label: 12 Months
+        summary: Scale the operating model.
     items:
       - Published a new starter kit for launch checklists.
       - Added exportable PDF summaries.
@@ -65,7 +62,7 @@ If `subtitle` is omitted, the active stage's `summary` is used instead.
 | --- | --- | --- | --- |
 | `title` | yes | string | |
 | `subtitle` | | string | |
-| `content.stage` | yes | string | `completed`, `in-progress`, `planned`, `future` |
+| `content.stage` | yes | string | Must match one key in `content.stages` |
 | `content.deliverables_heading` | | string | |
 | `content.focus_areas_heading` | | string | |
 | `content.footer_link_label` | | string | |
@@ -73,10 +70,10 @@ If `subtitle` is omitted, the active stage's `summary` is used instead.
 | `content.focus_areas_fa_icon` | | string | Defaults to `fa-bullseye` |
 | `content.theme_fa_icon` | | string | Defaults to `fa-chevron-right` |
 | `content.footer_link_fa_icon` | | string | Defaults to `fa-github` |
-| `content.stages` | yes | object | Four stage strip entries |
+| `content.stages` | yes | object | 2 to 6 stage strip entries, rendered in authored order |
 | `content.items` | yes | string[] | Active stage items |
 | `content.themes` | yes | array | Active stage themes |
 
-The progress timeline schema is documented in [presentation.yaml](/schema/presentation#progress-timeline).
+Stage keys may use the existing `completed`, `in-progress`, `planned`, and `future` shape, or custom labels such as `3-months`, `6-months`, and `12-months`. The progress timeline schema is documented in [presentation.yaml](/schema/presentation#progress-timeline).
 
 Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/shared/src/json-schema.spec.ts
+++ b/shared/src/json-schema.spec.ts
@@ -225,6 +225,62 @@ describe('public JSON Schemas', () => {
     ])
   })
 
+  it('accepts progress-timeline slides with three authored stages', async () => {
+    const ajv = await loadSchemas()
+    const document = {
+      schemaVersion: 1,
+      presentation: {
+        id: 'demo',
+        title: 'Demo',
+        subtitle: 'Example',
+        slides: [{
+          template: 'progress-timeline',
+          enabled: true,
+          title: 'Roadmap',
+          content: {
+            stage: '6-months',
+            stages: {
+              '3-months': { label: '3 Months', summary: 'Stabilize adoption.' },
+              '6-months': { label: '6 Months', summary: 'Expand core workflows.' },
+              '12-months': { label: '12 Months', summary: 'Scale the operating model.' },
+            },
+            items: ['Measure adoption'],
+            themes: [{ category: 'Adoption', target: 'Make progress explicit' }],
+          },
+        }],
+      },
+    }
+
+    expect(validateDocument(ajv, schemaIds.presentation, document)).toEqual([])
+  })
+
+  it('rejects progress-timeline schemas with too few stage entries', async () => {
+    const ajv = await loadSchemas()
+    const document = {
+      schemaVersion: 1,
+      presentation: {
+        id: 'demo',
+        title: 'Demo',
+        subtitle: 'Example',
+        slides: [{
+          template: 'progress-timeline',
+          enabled: true,
+          title: 'Roadmap',
+          content: {
+            stage: 'completed',
+            stages: {
+              completed: { label: 'Completed', summary: 'Delivered work.' },
+            },
+            items: ['Measure adoption'],
+            themes: [{ category: 'Adoption', target: 'Make progress explicit' }],
+          },
+        }],
+      },
+    }
+
+    expect(validateDocument(ajv, schemaIds.presentation, document).length).toBeGreaterThan(0)
+  })
+
   it('keeps the public Font Awesome icon schema aligned with runtime validation', async () => {
     const definitions = JSON.parse(await readFile(resolve(publicSchemaRoot, 'schema/defs.schema.json'), 'utf8'))
     const fontAwesomeIconEnum = definitions.$defs.fontAwesomeIcon.enum

--- a/shared/src/templates/progress-timeline-validation.spec.ts
+++ b/shared/src/templates/progress-timeline-validation.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateTemplateSlide } from './validation'
+
+const validProgressTimelineSlide = {
+  title: 'Progress',
+  content: {
+    stage: 'planned',
+    stages: {
+      completed: { label: 'Done', summary: 'Completed work' },
+      'in-progress': { label: 'Now', summary: 'Current work' },
+      planned: { label: 'Next', summary: 'Planned work' },
+      future: { label: 'Later', summary: 'Future work' },
+    },
+    items: ['Ship it'],
+    themes: [{ category: 'Quality', target: 'Keep gates green' }],
+  },
+} as const
+
+describe('progress-timeline validation', () => {
+  it('accepts slides with three authored stages', () => {
+    expect(() =>
+      validateTemplateSlide(
+        'progress-timeline',
+        {
+          ...validProgressTimelineSlide,
+          content: {
+            ...validProgressTimelineSlide.content,
+            stage: '6-months',
+            stages: {
+              '3-months': { label: '3 Months', summary: 'Stabilize adoption.' },
+              '6-months': { label: '6 Months', summary: 'Expand core workflows.' },
+              '12-months': { label: '12 Months', summary: 'Scale the operating model.' },
+            },
+          },
+        },
+        'slides[progress]',
+      ),
+    ).not.toThrow()
+  })
+
+  it('rejects slides when the active stage is not authored', () => {
+    expect(() =>
+      validateTemplateSlide(
+        'progress-timeline',
+        {
+          ...validProgressTimelineSlide,
+          content: {
+            ...validProgressTimelineSlide.content,
+            stage: 'future',
+            stages: {
+              completed: { label: 'Done', summary: 'Completed work' },
+              planned: { label: 'Next', summary: 'Planned work' },
+            },
+          },
+        },
+        'slides[progress]',
+      ),
+    ).toThrow('slides[progress].content.stage must match one of the keys in slides[progress].content.stages.')
+  })
+
+  it('rejects slides with fewer than two stages', () => {
+    expect(() =>
+      validateTemplateSlide(
+        'progress-timeline',
+        {
+          ...validProgressTimelineSlide,
+          content: {
+            ...validProgressTimelineSlide.content,
+            stages: {
+              completed: { label: 'Done', summary: 'Completed work' },
+            },
+          },
+        },
+        'slides[progress]',
+      ),
+    ).toThrow('slides[progress].content.stages must include at least 2 stages.')
+  })
+
+  it('rejects slides with more than six stages', () => {
+    expect(() =>
+      validateTemplateSlide(
+        'progress-timeline',
+        {
+          ...validProgressTimelineSlide,
+          content: {
+            ...validProgressTimelineSlide.content,
+            stage: 'stage-7',
+            stages: {
+              'stage-1': { label: 'Stage 1', summary: 'First stage' },
+              'stage-2': { label: 'Stage 2', summary: 'Second stage' },
+              'stage-3': { label: 'Stage 3', summary: 'Third stage' },
+              'stage-4': { label: 'Stage 4', summary: 'Fourth stage' },
+              'stage-5': { label: 'Stage 5', summary: 'Fifth stage' },
+              'stage-6': { label: 'Stage 6', summary: 'Sixth stage' },
+              'stage-7': { label: 'Stage 7', summary: 'Seventh stage' },
+            },
+          },
+        },
+        'slides[progress]',
+      ),
+    ).toThrow('slides[progress].content.stages must include no more than 6 stages.')
+  })
+})

--- a/shared/src/templates/validation.spec.ts
+++ b/shared/src/templates/validation.spec.ts
@@ -2,6 +2,30 @@ import { describe, expect, it } from 'vitest'
 
 import { validateTemplateSlide } from './validation'
 
+const validRoadmapStages = {
+  completed: { label: 'Done', summary: 'Completed work' },
+  'in-progress': { label: 'Now', summary: 'Current work' },
+  planned: { label: 'Next', summary: 'Planned work' },
+  future: { label: 'Later', summary: 'Future work' },
+} as const
+
+const validProgressTimelineSlide = {
+  title: 'Progress',
+  content: {
+    stage: 'planned',
+    deliverables_heading: 'Deliverables',
+    focus_areas_heading: 'Focus',
+    footer_link_label: 'Roadmap',
+    item_fa_icon: 'fa-chevron-right',
+    focus_areas_fa_icon: 'fa-bullseye',
+    theme_fa_icon: 'fa-check',
+    footer_link_fa_icon: 'fa-github',
+    stages: validRoadmapStages,
+    items: ['Ship it'],
+    themes: [{ category: 'Quality', target: 'Keep gates green' }],
+  },
+} as const
+
 describe('template validation', () => {
   it('accepts every supported template shape', () => {
     const validSlides = {
@@ -32,27 +56,7 @@ describe('template validation', () => {
           featured_release_ids: ['v1'],
         },
       },
-      'progress-timeline': {
-        title: 'Progress',
-        content: {
-          stage: 'planned',
-          deliverables_heading: 'Deliverables',
-          focus_areas_heading: 'Focus',
-          footer_link_label: 'Roadmap',
-          item_fa_icon: 'fa-chevron-right',
-          focus_areas_fa_icon: 'fa-bullseye',
-          theme_fa_icon: 'fa-check',
-          footer_link_fa_icon: 'fa-github',
-          stages: {
-            completed: { label: 'Done', summary: 'Completed work' },
-            'in-progress': { label: 'Now', summary: 'Current work' },
-            planned: { label: 'Next', summary: 'Planned work' },
-            future: { label: 'Later', summary: 'Future work' },
-          },
-          items: ['Ship it'],
-          themes: [{ category: 'Quality', target: 'Keep gates green' }],
-        },
-      },
+      'progress-timeline': validProgressTimelineSlide,
       people: {
         title: 'People',
         content: {
@@ -147,8 +151,18 @@ describe('template validation', () => {
       validateTemplateSlide('section-title', { content: { title: 'Title', subtitle: 'Support' } }, 'slides[0]'),
     ).not.toThrow()
     expect(() =>
-      validateTemplateSlide('progress-timeline', { title: 'Progress', content: { stage: 'blocked' } }, 'slides[1]'),
-    ).toThrow('slides[1].content.stage must be one of completed, in-progress, planned, or future.')
+      validateTemplateSlide(
+        'progress-timeline',
+        {
+          ...validProgressTimelineSlide,
+          content: {
+            ...validProgressTimelineSlide.content,
+            stage: 'blocked',
+          },
+        },
+        'slides[1]',
+      ),
+    ).toThrow('slides[1].content.stage must match one of the keys in slides[1].content.stages.')
     expect(() =>
       validateTemplateSlide('metrics-and-links', { title: 'Metrics', content: { stat_keys: [], mentions: [{ type: 'post', title: 'Post', url: 'https://example.test' }] } }, 'slides[2]'),
     ).toThrow('slides[2].content.mentions[0] must provide url and url_label together.')

--- a/shared/src/templates/validation.ts
+++ b/shared/src/templates/validation.ts
@@ -10,13 +10,39 @@ import {
 } from '../validation/assertions'
 import type { SlideTemplateId } from './templateIds'
 
-const roadmapStageStatuses = new Set(['completed', 'in-progress', 'planned', 'future'])
-const roadmapStageKeys = ['completed', 'in-progress', 'planned', 'future'] as const
+const minimumRoadmapStageCount = 2
+const maximumRoadmapStageCount = 6
 
 function assertRoadmapStageContent(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
   assertNonBlankString(value.label, `${path}.label`)
   assertNonBlankString(value.summary, `${path}.summary`)
+}
+
+function assertRoadmapStages(value: unknown, activeStage: unknown, path: string): void {
+  assert(isRecord(value), `${path}.stages must be an object.`)
+  assertNonBlankString(activeStage, `${path}.stage`)
+  const activeStageKey = activeStage as string
+
+  const stageEntries = Object.entries(value)
+  assert(
+    stageEntries.length >= minimumRoadmapStageCount,
+    `${path}.stages must include at least ${String(minimumRoadmapStageCount)} stages.`,
+  )
+  assert(
+    stageEntries.length <= maximumRoadmapStageCount,
+    `${path}.stages must include no more than ${String(maximumRoadmapStageCount)} stages.`,
+  )
+
+  stageEntries.forEach(([key, stage]) => {
+    assert(key.trim().length > 0, `${path}.stages keys must not be blank.`)
+    assertRoadmapStageContent(stage, `${path}.stages.${key}`)
+  })
+
+  assert(
+    Object.prototype.hasOwnProperty.call(value, activeStageKey),
+    `${path}.stage must match one of the keys in ${path}.stages.`,
+  )
 }
 
 function assertRoadmapTheme(value: unknown, path: string): void {
@@ -170,11 +196,6 @@ const progressTimelineValidator: SlideTemplateValidator = (slide, path) => {
     ],
     `${path}.content`,
   )
-  assertNonBlankString(content.stage, `${path}.content.stage`)
-  assert(
-    roadmapStageStatuses.has(content.stage),
-    `${path}.content.stage must be one of completed, in-progress, planned, or future.`,
-  )
   assertOptionalString(content.deliverables_heading, `${path}.content.deliverables_heading`)
   assertOptionalString(content.focus_areas_heading, `${path}.content.focus_areas_heading`)
   assertOptionalString(content.footer_link_label, `${path}.content.footer_link_label`)
@@ -182,13 +203,7 @@ const progressTimelineValidator: SlideTemplateValidator = (slide, path) => {
   assertOptionalFontAwesomeIcon(content.focus_areas_fa_icon, `${path}.content.focus_areas_fa_icon`)
   assertOptionalFontAwesomeIcon(content.theme_fa_icon, `${path}.content.theme_fa_icon`)
   assertOptionalFontAwesomeIcon(content.footer_link_fa_icon, `${path}.content.footer_link_fa_icon`)
-  assert(isRecord(content.stages), `${path}.content.stages must be an object.`)
-  for (const key of roadmapStageKeys) {
-    assertRoadmapStageContent(
-      (content.stages as Record<string, unknown>)[key],
-      `${path}.content.stages.${key}`,
-    )
-  }
+  assertRoadmapStages(content.stages, content.stage, `${path}.content`)
   assertStringArray(content.items, `${path}.content.items`)
   assertRoadmapThemes(content.themes, `${path}.content.themes`)
 }

--- a/slides/content/presentations/2025-open-source-example/presentation.yaml
+++ b/slides/content/presentations/2025-open-source-example/presentation.yaml
@@ -83,9 +83,6 @@ presentation:
           planned:
             label: Planned
             summary: Scoped for Q2 2025.
-          future:
-            label: Future
-            summary: Under discussion.
         items:
           - Plugin system with local and registry-based resolution
           - Structured error messages with fix suggestions

--- a/slides/public/schema/presentation.schema.json
+++ b/slides/public/schema/presentation.schema.json
@@ -198,7 +198,7 @@
               "required": ["stage", "stages", "items", "themes"],
               "additionalProperties": false,
               "properties": {
-                "stage": { "enum": ["completed", "in-progress", "planned", "future"] },
+                "stage": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "deliverables_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "focus_areas_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                 "footer_link_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
@@ -208,14 +208,10 @@
                 "footer_link_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
                 "stages": {
                   "type": "object",
-                  "required": ["completed", "in-progress", "planned", "future"],
-                  "additionalProperties": false,
-                  "properties": {
-                    "completed": { "$ref": "defs.schema.json#/$defs/roadmapStage" },
-                    "in-progress": { "$ref": "defs.schema.json#/$defs/roadmapStage" },
-                    "planned": { "$ref": "defs.schema.json#/$defs/roadmapStage" },
-                    "future": { "$ref": "defs.schema.json#/$defs/roadmapStage" }
-                  }
+                  "minProperties": 2,
+                  "maxProperties": 6,
+                  "propertyNames": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                  "additionalProperties": { "$ref": "defs.schema.json#/$defs/roadmapStage" }
                 },
                 "items": { "$ref": "defs.schema.json#/$defs/stringArray" },
                 "themes": {


### PR DESCRIPTION
## What

Updates `progress-timeline` so authors can define 2 to 6 stage entries instead of being forced into the fixed `completed`, `in-progress`, `planned`, and `future` keys.

The renderer now uses authored stage order, validation requires `content.stage` to match one authored stage key, and the public schema/docs/examples/tests are updated to cover three-stage timelines.

## Related issue

Closes #164

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (describe below)

## Breaking changes

- [ ] Yes (describe below)
- [x] No

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes