### PR TITLE
changing schema for progress-timeline to make it more generic

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -12,6 +12,7 @@
     "Ferreira",
     "GitHub",
     "GitOps",
+    "keyvalue",
     "Ladybird",
     "lightbox",
     "OpenSSF",

--- a/app/e2e/fixtures/content-cli-demo/presentations/2026-demo/presentation.yaml
+++ b/app/e2e/fixtures/content-cli-demo/presentations/2026-demo/presentation.yaml
@@ -42,8 +42,11 @@ presentation:
           future:
             label: Future
             summary: Default roadmap fixture content.
-        items: []
-        themes: []
+        sections:
+          - title: Current focus
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: Default roadmap fixture content.
     - template: people
       enabled: true
       title: Contributors

--- a/app/e2e/fixtures/content/presentations/2025-template-sparse/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2025-template-sparse/presentation.yaml
@@ -53,11 +53,13 @@ presentation:
           future:
             label: Future
             summary: Later
-        items:
-          - One
-        themes:
-          - category: Theme
-            target: Target
+        sections:
+          - type: richtext
+            body: One
+          - type: keyvalue
+            body:
+              - key: Theme
+                value: Target
     - template: people
       enabled: true
       title: Contributors

--- a/app/e2e/fixtures/content/presentations/2026-q1/presentation.yaml
+++ b/app/e2e/fixtures/content/presentations/2026-q1/presentation.yaml
@@ -58,8 +58,6 @@ presentation:
       title: "Roadmap: Completed"
       content:
         stage: completed
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View full roadmap & milestones on GitHub
         stages:
           completed:
@@ -76,25 +74,31 @@ presentation:
           future:
             label: Future
             summary: Version 3.x remains centered on a more interoperable file format and long-horizon project maturity goals.
-        items:
-          - Reusable briefing templates landed for roadmap, release, and community updates.
-          - Aurora Notes' content manifest gained clearer publication metadata.
-          - Starter examples now cover weekly notes, planning reviews, and decision logs.
-          - Preview and archive fixes landed for nested routes, ordering, and template visibility.
-        themes:
-          - category: Team Readiness
-            target: Templates and preview fixes continue to make Aurora Notes easier for teams to adopt.
-          - category: Publishing Flow
-            target: Archive ordering and nested routes improved compatibility with static hosting workflows.
-          - category: Authoring Quality
-            target: Validation and empty-state updates reduced friction in day-to-day editing.
+        sections:
+          - title: Key deliverables
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Reusable briefing templates landed for roadmap, release, and community updates.
+              - Aurora Notes' content manifest gained clearer publication metadata.
+              - Starter examples now cover weekly notes, planning reviews, and decision logs.
+              - Preview and archive fixes landed for nested routes, ordering, and template visibility.
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Team Readiness
+                value: Templates and preview fixes continue to make Aurora Notes easier for teams to adopt.
+              - key: Publishing Flow
+                value: Archive ordering and nested routes improved compatibility with static hosting workflows.
+              - key: Authoring Quality
+                value: Validation and empty-state updates reduced friction in day-to-day editing.
     - template: progress-timeline
       enabled: true
       title: "Roadmap: In Progress"
       content:
         stage: in-progress
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View full roadmap & milestones on GitHub
         stages:
           completed:
@@ -111,25 +115,35 @@ presentation:
           future:
             label: Future
             summary: Version 3.x remains centered on a more interoperable file format and long-horizon project maturity goals.
-        items:
-          - Presentation search coverage and keyboard navigation coverage both landed in March.
-          - Documentation cleanup continued with dependency updates, template example fixes, and contributor guidance changes.
-          - Workflow and dependency maintenance continued across CI actions and build assets.
-          - The public planning board opened on March 8 to align future work under shared themes.
-        themes:
-          - category: Maintainability
-            target: Testing coverage, dependency hygiene, and build cleanup remain active themes.
-          - category: Community Confidence
-            target: Contributor guidance and documentation are being tightened as the project grows.
-          - category: Release Notes
-            target: Release-readiness work continued even without a tagged GitHub release in the window.
+        sections:
+          - title: Key deliverables
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: >-
+              - Presentation search coverage and keyboard navigation coverage both landed in March.
+
+              - Documentation cleanup continued with dependency updates, template example fixes, and contributor
+              guidance changes.
+
+              - Workflow and dependency maintenance continued across CI actions and build assets.
+
+              - The public planning board opened on March 8 to align future work under shared themes.
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Maintainability
+                value: Testing coverage, dependency hygiene, and build cleanup remain active themes.
+              - key: Community Confidence
+                value: Contributor guidance and documentation are being tightened as the project grows.
+              - key: Release Notes
+                value: Release-readiness work continued even without a tagged GitHub release in the window.
     - template: progress-timeline
       enabled: true
       title: "Roadmap: Planned"
       content:
         stage: planned
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View full roadmap & milestones on GitHub
         stages:
           completed:
@@ -146,25 +160,31 @@ presentation:
           future:
             label: Future
             summary: Version 3.x remains centered on a more interoperable file format and long-horizon project maturity goals.
-        items:
-          - Workspace presets, review checklists, and project templates remain part of the team-readiness backlog.
-          - Content catalogs, authoring guides, and CLI preview polish are called out as future deliverables.
-          - UX work includes search ergonomics, WCAG accessibility baselines, and a UI style guide.
-          - Export options, preview hooks, and publishing workflows are listed under automation.
-        themes:
-          - category: Team Readiness
-            target: Support team adoption without abandoning Git-based workflows.
-          - category: UX & Accessibility
-            target: Improve approachability, consistency, and accessibility across the product.
-          - category: Automation & Integration
-            target: Make Aurora Notes easier to connect to publishing workflows and tooling.
+        sections:
+          - title: Key deliverables
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Workspace presets, review checklists, and project templates remain part of the team-readiness backlog.
+              - Content catalogs, authoring guides, and CLI preview polish are called out as future deliverables.
+              - UX work includes search ergonomics, WCAG accessibility baselines, and a UI style guide.
+              - Export options, preview hooks, and publishing workflows are listed under automation.
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Team Readiness
+                value: Support team adoption without abandoning Git-based workflows.
+              - key: UX & Accessibility
+                value: Improve approachability, consistency, and accessibility across the product.
+              - key: Automation & Integration
+                value: Make Aurora Notes easier to connect to publishing workflows and tooling.
     - template: progress-timeline
       enabled: true
       title: "Roadmap: Future"
       content:
         stage: future
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View full roadmap & milestones on GitHub
         stages:
           completed:
@@ -181,18 +201,26 @@ presentation:
           future:
             label: Future
             summary: Version 3.x remains centered on a more interoperable file format and long-horizon project maturity goals.
-        items:
-          - Version 3.x is expected to move toward reusable content packages instead of one-off decks.
-          - Portable metadata is the likely direction for the future project manifest.
-          - The project page explicitly calls out integrations with adjacent publishing tools.
-          - The long-horizon roadmap also aims for a stable template marketplace.
-        themes:
-          - category: Portable Metadata
-            target: Center authored updates around reusable project data and interchange.
-          - category: Publishing Ecosystem
-            target: Reduce friction between Aurora Notes and other open-source publishing tools.
-          - category: Project Maturity
-            target: Continue the path from Demo Lab toward stable-template maturity.
+        sections:
+          - title: Key deliverables
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Version 3.x is expected to move toward reusable content packages instead of one-off decks.
+              - Portable metadata is the likely direction for the future project manifest.
+              - The project page explicitly calls out integrations with adjacent publishing tools.
+              - The long-horizon roadmap also aims for a stable template marketplace.
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Portable Metadata
+                value: Center authored updates around reusable project data and interchange.
+              - key: Publishing Ecosystem
+                value: Reduce friction between Aurora Notes and other open-source publishing tools.
+              - key: Project Maturity
+                value: Continue the path from Demo Lab toward stable-template maturity.
     - template: people
       enabled: true
       title: Contributor Spotlight
@@ -234,8 +262,8 @@ presentation:
             url_label: View the project page
             url: https://example.org/projects/aurora-notes/
           - type: Documentation
-            title: The version 2 documentation continues to cover configuration, templates, testing, and content metadata for current
-              users and contributors.
+            title: The version 2 documentation continues to cover configuration, templates, testing, and content metadata for
+              current users and contributors.
             url_label: Browse the docs
             url: https://docs.example.org/aurora-notes
     - template: image-and-bullets

--- a/app/e2e/presentation.slides.spec.ts
+++ b/app/e2e/presentation.slides.spec.ts
@@ -140,18 +140,20 @@ async function assertSlideContent(page: Page, slide: PresentationSlide): Promise
       const roadmapSlide: RoadmapSlide = slide
       const stage = roadmapSlide.content.stages[roadmapSlide.content.stage]
       await expect(page.getByText(`Roadmap: ${stage?.label}`)).toBeVisible()
-      await expect(page.getByText(roadmapSlide.content.deliverables_heading ?? 'Key deliverables')).toBeVisible()
-      await expect(page.getByText(roadmapSlide.content.focus_areas_heading ?? 'Focus areas')).toBeVisible()
       for (const timelineStage of Object.values(roadmapSlide.content.stages)) {
         await expect(page.getByText(timelineStage.label, { exact: true }).first()).toBeVisible()
       }
       await expect(page.getByText(stage?.summary ?? '', { exact: true }).first()).toBeVisible()
-      for (const item of roadmapSlide.content.items) {
-        await expect(page.getByText(item)).toBeVisible()
-      }
-      for (const theme of roadmapSlide.content.themes) {
-        await expect(page.getByText(theme.category, { exact: true }).first()).toBeVisible()
-        await expect(page.getByText(theme.target)).toBeVisible()
+      for (const section of roadmapSlide.content.sections) {
+        if (section.title) {
+          await expect(page.getByText(section.title, { exact: true }).first()).toBeVisible()
+        }
+        if (section.type === 'keyvalue') {
+          for (const row of section.body) {
+            await expect(page.getByText(row.key, { exact: true }).first()).toBeVisible()
+            await expect(page.getByText(row.value)).toBeVisible()
+          }
+        }
       }
       if (roadmapSlide.content.footer_link_label) {
         await expect(page.getByRole('link', { name: roadmapSlide.content.footer_link_label })).toHaveAttribute(

--- a/app/e2e/presentation.sparse.spec.ts
+++ b/app/e2e/presentation.sparse.spec.ts
@@ -67,7 +67,8 @@ async function assertSparseSlide(page: Page, slideNumber: number): Promise<void>
     case 'progress-timeline':
       await expect(page.getByRole('heading', { name: 'Roadmap' })).toBeVisible()
       await expect(page.locator('.progress-timeline__item')).toHaveCount(4)
-      await expect(page.locator('.card-eyebrow')).toHaveCount(1)
+      await expect(page.locator('.detail-card')).toHaveCount(2)
+      await expect(page.locator('.card-eyebrow')).toHaveCount(0)
       await expect(page.locator('.card-title')).toHaveCount(0)
       await expect(page.locator('.footer-link')).toHaveCount(0)
       break

--- a/app/src/components/slides/RoadmapSlideView.spec.ts
+++ b/app/src/components/slides/RoadmapSlideView.spec.ts
@@ -58,9 +58,53 @@ describe('RoadmapSlideView', () => {
     })
 
     expect(wrapper.text()).toContain('Roadmap: Completed')
-    expect(wrapper.find('.card-eyebrow').exists()).toBe(true)
     expect(wrapper.find('.card-title').exists()).toBe(true)
     expect(wrapper.find('.footer-link').exists()).toBe(false)
+  })
+
+  it('renders declarative progress timeline sections', () => {
+    const slide = roadmapSlides[0]
+
+    if (!slide || slide.template !== 'progress-timeline') {
+      throw new Error('Expected roadmap slide in fixture data')
+    }
+
+    const wrapper = mount(RoadmapSlideView, {
+      props: {
+        presentation: record.presentation,
+        site: contentRepository.getSiteContent(),
+        slide: {
+          ...slide,
+          content: {
+            stage: slide.content.stage,
+            stages: slide.content.stages,
+            footer_link_label: slide.content.footer_link_label,
+            sections: [
+              {
+                title: 'What happened',
+                fa_icon: 'fa-check',
+                type: 'richtext',
+                body: 'First paragraph.\n\n- Detail one\n- Detail two',
+              },
+              {
+                title: 'Signals',
+                fa_icon: 'fa-bullseye',
+                type: 'keyvalue',
+                separator_fa_icon: 'fa-arrow-right',
+                body: [{ key: 'Quality', value: 'Keep gates green' }],
+              },
+            ],
+          },
+        },
+        slideNumber: 4,
+        slideTotal: 12,
+      },
+    })
+
+    expect(wrapper.findAll('.detail-card')).toHaveLength(2)
+    expect(wrapper.find('.detail-rich-text .rich-text__paragraph').text()).toBe('First paragraph.')
+    expect(wrapper.findAll('.detail-rich-text .rich-text__item')).toHaveLength(2)
+    expect(wrapper.find('.key-value-rows__key').text()).toBe('Quality')
   })
 
   it('renders timeline stages from authored stage keys', () => {
@@ -100,7 +144,7 @@ describe('RoadmapSlideView', () => {
     expect(wrapper.text()).toContain('6 Months')
   })
 
-  it('omits optional roadmap headings and stage eyebrow when slide-local labels are blank', () => {
+  it('omits optional section headings and stage label when slide-local labels are blank', () => {
     const slide = roadmapSlides[2]
 
     if (!slide || slide.template !== 'progress-timeline') {
@@ -117,9 +161,13 @@ describe('RoadmapSlideView', () => {
           subtitle: undefined,
           content: {
             ...slide.content,
-            deliverables_heading: undefined,
-            focus_areas_heading: undefined,
             footer_link_label: undefined,
+            sections: [
+              {
+                type: 'richtext',
+                body: 'Unlabeled detail',
+              },
+            ],
             stages: {
               ...slide.content.stages,
               planned: {
@@ -137,7 +185,6 @@ describe('RoadmapSlideView', () => {
 
     expect(wrapper.find('.card-eyebrow').exists()).toBe(false)
     expect(wrapper.find('.card-title').exists()).toBe(false)
-    expect(wrapper.find('.section-heading').exists()).toBe(false)
     expect(wrapper.find('.footer-link').exists()).toBe(false)
     expect(wrapper.find('.standard-slide-layout__subtitle').exists()).toBe(false)
 

--- a/app/src/components/slides/RoadmapSlideView.vue
+++ b/app/src/components/slides/RoadmapSlideView.vue
@@ -2,13 +2,11 @@
 import { computed } from 'vue'
 
 import StandardSlideLayout from '../presentation/StandardSlideLayout.vue'
-import ContentList from '../ui/ContentList.vue'
+import FaIcon from '../ui/FaIcon.vue'
 import FooterActionLink from '../ui/FooterActionLink.vue'
 import KeyValueRows from '../ui/KeyValueRows.vue'
 import ProgressTimeline from '../ui/ProgressTimeline.vue'
-import SectionHeading from '../ui/SectionHeading.vue'
-import { resolveRoadmapLabels } from '../../content/contentDefaults'
-
+import RichText from '../ui/RichText.vue'
 import type {
   PresentationContent,
   RoadmapSlide,
@@ -44,11 +42,11 @@ const timelineStages = computed(() =>
   }),
 )
 const activeStage = computed(() => stages.value?.[props.slide.content.stage])
-const roadmapLabels = computed(() => resolveRoadmapLabels(props.slide.content))
-const itemFaIcon = computed(() => props.slide.content.item_fa_icon ?? 'fa-chevron-right')
-const focusAreasFaIcon = computed(() => props.slide.content.focus_areas_fa_icon ?? 'fa-bullseye')
-const themeFaIcon = computed(() => props.slide.content.theme_fa_icon ?? 'fa-chevron-right')
 const footerLinkFaIcon = computed(() => props.slide.content.footer_link_fa_icon ?? 'fa-github')
+const footerLinkLabel = computed(() => {
+  const label = props.slide.content.footer_link_label?.trim()
+  return label && label.length > 0 ? label : undefined
+})
 </script>
 
 <template>
@@ -70,29 +68,32 @@ const footerLinkFaIcon = computed(() => props.slide.content.footer_link_fa_icon 
         }))"
       />
 
-      <div class="details-grid">
-        <section class="detail-card detail-card--primary">
-          <p v-if="activeStage?.label" class="card-eyebrow">{{ activeStage.label }}</p>
-          <h2 v-if="roadmapLabels.deliverables" class="card-title">{{ roadmapLabels.deliverables }}</h2>
-          <ContentList :items="slide.content.items" marker="icon" :fa-icon="itemFaIcon" class="detail-list" />
-        </section>
-
-        <section class="detail-card detail-card--secondary">
-          <SectionHeading v-if="roadmapLabels.focusAreas" :fa-icon="focusAreasFaIcon" :title="roadmapLabels.focusAreas" />
+      <div class="details-grid" :style="{ '--progress-detail-columns': String(slide.content.sections.length) }">
+        <section
+          v-for="(section, index) in slide.content.sections"
+          class="detail-card"
+          :key="`${section.type}-${section.title ?? index}`"
+        >
+          <h2 v-if="section.title" class="card-title">
+            <FaIcon v-if="section.fa_icon" :fa-icon="section.fa_icon" class="card-title__icon" />
+            <span>{{ section.title }}</span>
+          </h2>
+          <RichText v-if="section.type === 'richtext'" :text="section.body" class="detail-rich-text" />
           <KeyValueRows
-            :rows="slide.content.themes.map((theme) => ({ key: theme.category, value: theme.target }))"
-            :value-fa-icon="themeFaIcon"
+            v-else
+            :rows="section.body"
+            :value-fa-icon="section.separator_fa_icon ?? 'fa-chevron-right'"
             class="themes-grid"
           />
         </section>
       </div>
 
       <FooterActionLink
-        v-if="roadmapLabels.footerLink"
+        v-if="footerLinkLabel"
         class="footer-link"
         :href="site.links.repository.url"
         :fa-icon="footerLinkFaIcon"
-        :label="roadmapLabels.footerLink"
+        :label="footerLinkLabel"
       />
     </div>
   </StandardSlideLayout>
@@ -105,60 +106,50 @@ const footerLinkFaIcon = computed(() => props.slide.content.footer_link_fa_icon 
   flex-direction: column;
   gap: 2rem;
 }
-
 .details-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+  grid-template-columns: repeat(var(--progress-detail-columns), minmax(0, 1fr));
   gap: 1.5rem;
   flex: 1;
 }
-
 .detail-card {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  align-content: flex-start;
   min-height: 0;
+  padding: 1.5rem 1.75rem;
   border-radius: 12px;
+  border: 1px solid #333344;
   background-color: #252535;
 }
-
-.detail-card--primary {
-  padding: 1.75rem 1.75rem 1.5rem;
-  border-left: 4px solid #e8341c;
-}
-
-.detail-card--secondary {
-  padding: 1.5rem 1.75rem;
-  border: 1px solid #333344;
-}
-
-.card-eyebrow {
-  margin: 0 0 0.65rem;
-  color: #e8341c;
-  font: 600 0.82rem/1.2 var(--font-mono);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
 .card-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   margin: 0 0 1.25rem;
+  padding-bottom: 0.7rem;
+  border-bottom: 1px solid #333344;
   color: #ffffff;
-  font-size: 1.6rem;
+  font-size: 1.25rem;
   font-weight: 600;
 }
-
+.card-title__icon {
+  color: #e8341c;
+  flex-shrink: 0;
+}
+.detail-rich-text {
+  color: #d0d0e8;
+  line-height: 1.5;
+}
 @media (max-width: 1199px) {
   .details-grid {
     grid-template-columns: 1fr;
   }
 }
-
 @media (max-width: 767px) {
   .content-wrapper {
     gap: 1.5rem;
   }
-
-  .detail-card--primary,
-  .detail-card--secondary {
+  .detail-card {
     padding: 1.25rem;
   }
 }

--- a/app/src/content/ContentValidator.spec.ts
+++ b/app/src/content/ContentValidator.spec.ts
@@ -64,8 +64,6 @@ const createValidPresentationDocument = () => ({
         title: 'Roadmap',
         content: {
           stage: 'completed',
-          deliverables_heading: 'Key deliverables',
-          focus_areas_heading: 'Focus areas',
           footer_link_label: 'View full roadmap & milestones on GitHub',
           stages: {
             completed: {
@@ -85,8 +83,18 @@ const createValidPresentationDocument = () => ({
               summary: 'Later',
             },
           },
-          items: ['One'],
-          themes: [{ category: 'Theme', target: 'Target' }],
+          sections: [
+            {
+              title: 'Key deliverables',
+              type: 'richtext',
+              body: 'One',
+            },
+            {
+              title: 'Focus areas',
+              type: 'keyvalue',
+              body: [{ key: 'Theme', value: 'Target' }],
+            },
+          ],
         },
       },
       {

--- a/app/src/content/contentDefaults.spec.ts
+++ b/app/src/content/contentDefaults.spec.ts
@@ -10,7 +10,6 @@ import {
   resolvePresentationChromeLabel,
   resolvePresentationsPageContent,
   resolvePresentationToolbarContent,
-  resolveRoadmapLabels,
   resolveTitleSlideContent,
 } from './contentDefaults'
 
@@ -18,14 +17,9 @@ describe('contentDefaults', () => {
   const site = contentRepository.getSiteContent()
   const record = contentRepository.getPresentation('2026-q1')
   const titleSlide = record.presentation.slides.find((slide) => slide.template === 'hero')
-  const roadmapSlide = record.presentation.slides.find((slide) => slide.template === 'progress-timeline')
 
   if (!titleSlide || titleSlide.template !== 'hero') {
     throw new Error('Expected title slide in fixture data')
-  }
-
-  if (!roadmapSlide || roadmapSlide.template !== 'progress-timeline') {
-    throw new Error('Expected roadmap slide in fixture data')
   }
 
   it('normalizes configured site content', () => {
@@ -208,20 +202,15 @@ describe('contentDefaults', () => {
     })
   })
 
-  it('normalizes authored slide and roadmap labels', () => {
+  it('normalizes authored title slide labels', () => {
     expect(resolveTitleSlideContent(titleSlide)).toEqual({
       titlePrimary: 'Aurora',
       titleAccent: 'Notes',
       subtitlePrefix: 'Community Update',
     })
-    expect(resolveRoadmapLabels(roadmapSlide.content)).toEqual({
-      deliverables: 'Key deliverables',
-      focusAreas: 'Focus areas',
-      footerLink: 'View full roadmap & milestones on GitHub',
-    })
   })
 
-  it('returns undefined for blank title-slide and roadmap labels', () => {
+  it('returns undefined for blank title-slide labels', () => {
     expect(
       resolveTitleSlideContent({
         ...titleSlide,
@@ -236,19 +225,6 @@ describe('contentDefaults', () => {
       titlePrimary: undefined,
       titleAccent: undefined,
       subtitlePrefix: undefined,
-    })
-
-    expect(
-      resolveRoadmapLabels({
-        ...roadmapSlide.content,
-        deliverables_heading: '   ',
-        focus_areas_heading: '   ',
-        footer_link_label: '   ',
-      }),
-    ).toEqual({
-      deliverables: undefined,
-      focusAreas: undefined,
-      footerLink: undefined,
     })
   })
 })

--- a/app/src/content/contentDefaults.ts
+++ b/app/src/content/contentDefaults.ts
@@ -4,7 +4,6 @@ import type {
   HomeHeroContent,
   HomeLogoLinkContent,
   NavigationContent,
-  ProgressTimelineSlideContent,
   PresentationToolbarContent,
   PresentationsPageContent,
   SiteContent,
@@ -15,12 +14,6 @@ export interface TitleSlideResolvedContent {
   titlePrimary?: string
   titleAccent?: string
   subtitlePrefix?: string
-}
-
-export interface RoadmapResolvedLabels {
-  deliverables?: string
-  focusAreas?: string
-  footerLink?: string
 }
 
 export interface ResolvedAttributionContent {
@@ -177,12 +170,4 @@ export const resolveTitleSlideContent = (
   titlePrimary: trimOrUndefined(slide.content.title_primary),
   titleAccent: trimOrUndefined(slide.content.title_accent),
   subtitlePrefix: trimOrUndefined(slide.content.subtitle_prefix),
-})
-
-export const resolveRoadmapLabels = (
-  content: ProgressTimelineSlideContent,
-): RoadmapResolvedLabels => ({
-  deliverables: trimOrUndefined(content.deliverables_heading),
-  focusAreas: trimOrUndefined(content.focus_areas_heading),
-  footerLink: trimOrUndefined(content.footer_link_label),
 })

--- a/app/src/templates/validation.spec.ts
+++ b/app/src/templates/validation.spec.ts
@@ -88,12 +88,23 @@ const validSlides: Record<SlideTemplateId, Record<string, unknown>> = {
     title: 'Roadmap',
     content: {
       stage: 'completed',
-      deliverables_heading: 'Key deliverables',
-      focus_areas_heading: 'Focus areas',
       footer_link_label: 'View roadmap',
       stages: validRoadmapStages,
-      items: ['One'],
-      themes: [{ category: 'Theme', target: 'Target' }],
+      sections: [
+        {
+          title: 'Key deliverables',
+          fa_icon: 'fa-check',
+          type: 'richtext',
+          body: 'One',
+        },
+        {
+          title: 'Focus areas',
+          fa_icon: 'fa-bullseye',
+          type: 'keyvalue',
+          separator_fa_icon: 'fa-chevron-right',
+          body: [{ key: 'Theme', value: 'Target' }],
+        },
+      ],
     },
   },
   people: {
@@ -230,8 +241,12 @@ const sparseSlides: Record<SlideTemplateId, Record<string, unknown>> = {
     content: {
       stage: 'completed',
       stages: validRoadmapStages,
-      items: [],
-      themes: [],
+      sections: [
+        {
+          type: 'richtext',
+          body: 'One',
+        },
+      ],
     },
   },
   people: {
@@ -365,8 +380,12 @@ describe('template validation', () => {
       content: {
         stage: 'active',
         stages: validRoadmapStages,
-        items: [],
-        themes: [],
+        sections: [
+          {
+            type: 'richtext',
+            body: 'One',
+          },
+        ],
       },
     },
     people: {
@@ -493,8 +512,16 @@ describe('template validation', () => {
               '6-months': { label: '6 Months', summary: 'Expand core workflows.' },
               '12-months': { label: '12 Months', summary: 'Scale the operating model.' },
             },
-            items: ['Measure adoption'],
-            themes: [{ category: 'Adoption', target: 'Make progress explicit' }],
+            sections: [
+              {
+                type: 'richtext',
+                body: 'Measure adoption',
+              },
+              {
+                type: 'keyvalue',
+                body: [{ key: 'Adoption', value: 'Make progress explicit' }],
+              },
+            ],
           },
         },
         'slides[progress-timeline]',

--- a/app/src/types/content.ts
+++ b/app/src/types/content.ts
@@ -184,16 +184,32 @@ export interface TimelineSlideContent {
 
 export interface ProgressTimelineSlideContent {
   stage: RoadmapStageStatus
-  deliverables_heading?: string
-  focus_areas_heading?: string
   footer_link_label?: string
-  item_fa_icon?: string
-  focus_areas_fa_icon?: string
-  theme_fa_icon?: string
   footer_link_fa_icon?: string
   stages: Record<RoadmapStageStatus, RoadmapStageSummary>
-  items: string[]
-  themes: RoadmapTheme[]
+  sections: ProgressTimelineSection[]
+}
+
+export interface ProgressTimelineRichTextSection {
+  title?: string
+  fa_icon?: string
+  type: 'richtext'
+  body: string
+}
+
+export interface ProgressTimelineKeyValueSection {
+  title?: string
+  fa_icon?: string
+  type: 'keyvalue'
+  separator_fa_icon?: string
+  body: ProgressTimelineKeyValueRow[]
+}
+
+export type ProgressTimelineSection = ProgressTimelineRichTextSection | ProgressTimelineKeyValueSection
+
+export interface ProgressTimelineKeyValueRow {
+  key: string
+  value: string
 }
 
 export interface PeopleSlideContent {
@@ -311,11 +327,6 @@ export interface CardGridItem {
 }
 
 export type RoadmapStageStatus = string
-
-export interface RoadmapTheme {
-  category: string
-  target: string
-}
 
 export interface RoadmapStageSummary {
   label: string

--- a/cli/examples-synced/community-update/presentations/2026-q1-community/presentation.yaml
+++ b/cli/examples-synced/community-update/presentations/2026-q1-community/presentation.yaml
@@ -58,8 +58,6 @@ presentation:
       subtitle: Community initiatives delivered
       content:
         stage: completed
-        deliverables_heading: Delivered
-        focus_areas_heading: Themes
         footer_link_label: View community roadmap
         stages:
           completed:
@@ -74,15 +72,23 @@ presentation:
           future:
             label: Future
             summary: Exploring for later in the year.
-        items:
-          - Launched 3 new learning paths on the developer portal
-          - Spoke at 4 conferences across 3 countries
-          - Shipped the community SDK with 15 code samples
-        themes:
-          - category: Education
-            target: Lower the barrier to entry for new developers.
-          - category: Reach
-            target: Grow awareness in new geographic markets.
+        sections:
+          - title: Delivered
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Launched 3 new learning paths on the developer portal
+              - Spoke at 4 conferences across 3 countries
+              - Shipped the community SDK with 15 code samples
+          - title: Themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Education
+                value: Lower the barrier to entry for new developers.
+              - key: Reach
+                value: Grow awareness in new geographic markets.
     - template: people
       enabled: true
       title: Community champions

--- a/cli/examples-synced/open-source-update/presentations/2026-q1-update/presentation.yaml
+++ b/cli/examples-synced/open-source-update/presentations/2026-q1-update/presentation.yaml
@@ -63,11 +63,7 @@ presentation:
       subtitle: What we shipped
       content:
         stage: completed
-        deliverables_heading: Shipped
-        focus_areas_heading: Themes
         footer_link_label: View full roadmap
-        item_fa_icon: fa-check
-        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -81,15 +77,23 @@ presentation:
           future:
             label: Future
             summary: Under discussion.
-        items:
-          - Plugin system with local and registry-based resolution
-          - Structured error messages with fix suggestions
-          - Shell completion for bash, zsh, and fish
-        themes:
-          - category: Extensibility
-            target: Let users add functionality without forking.
-          - category: Developer Experience
-            target: Reduce time-to-fix for common errors.
+        sections:
+          - title: Shipped
+            fa_icon: fa-check
+            type: richtext
+            body: |-
+              - Plugin system with local and registry-based resolution
+              - Structured error messages with fix suggestions
+              - Shell completion for bash, zsh, and fish
+          - title: Themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Extensibility
+                value: Let users add functionality without forking.
+              - key: Developer Experience
+                value: Reduce time-to-fix for common errors.
     - template: people
       enabled: true
       title: Contributor spotlight

--- a/cli/examples-synced/product-review/presentations/2026-q1-review/presentation.yaml
+++ b/cli/examples-synced/product-review/presentations/2026-q1-review/presentation.yaml
@@ -58,8 +58,6 @@ presentation:
       subtitle: Q1 deliverables
       content:
         stage: completed
-        deliverables_heading: Delivered
-        focus_areas_heading: Strategic themes
         footer_link_label: View full roadmap
         stages:
           completed:
@@ -74,15 +72,23 @@ presentation:
           future:
             label: Future
             summary: Under exploration.
-        items:
-          - Workspace redesign with customizable layouts
-          - API v3 with breaking change migration tool
-          - Self-serve onboarding flow for teams under 50
-        themes:
-          - category: User Experience
-            target: Reduce time-to-value for new workspace setups.
-          - category: Platform
-            target: Modernize the API for partner integrations.
+        sections:
+          - title: Delivered
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Workspace redesign with customizable layouts
+              - API v3 with breaking change migration tool
+              - Self-serve onboarding flow for teams under 50
+          - title: Strategic themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: User Experience
+                value: Reduce time-to-value for new workspace setups.
+              - key: Platform
+                value: Modernize the API for partner integrations.
     - template: people
       enabled: true
       title: Team spotlight

--- a/cli/examples-synced/security-posture/presentations/2026-q1-posture/presentation.yaml
+++ b/cli/examples-synced/security-posture/presentations/2026-q1-posture/presentation.yaml
@@ -57,8 +57,6 @@ presentation:
       subtitle: Q1 security initiatives
       content:
         stage: completed
-        deliverables_heading: Completed initiatives
-        focus_areas_heading: Focus areas
         footer_link_label: View security roadmap
         stages:
           completed:
@@ -73,15 +71,23 @@ presentation:
           future:
             label: Future
             summary: Under evaluation.
-        items:
-          - Migrated all services to automated dependency scanning
-          - Completed annual penetration test with zero critical findings
-          - Rolled out hardware security keys for all engineering staff
-        themes:
-          - category: Supply Chain
-            target: Eliminate unscanned dependencies from production.
-          - category: Authentication
-            target: Phishing-resistant credentials for all engineers.
+        sections:
+          - title: Completed initiatives
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Migrated all services to automated dependency scanning
+              - Completed annual penetration test with zero critical findings
+              - Rolled out hardware security keys for all engineering staff
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Supply Chain
+                value: Eliminate unscanned dependencies from production.
+              - key: Authentication
+                value: Phishing-resistant credentials for all engineers.
     - template: people
       enabled: true
       title: Security team

--- a/cli/src/init/InitPresentationBuilder.ts
+++ b/cli/src/init/InitPresentationBuilder.ts
@@ -189,8 +189,14 @@ export class InitPresentationBuilder {
                   summary: 'Longer-horizon work under consideration.',
                 },
               },
-              items: [],
-              themes: [],
+              sections: [
+                {
+                  title: 'Current focus',
+                  fa_icon: 'fa-chevron-right',
+                  type: 'richtext',
+                  body: 'Replace with progress details for the active stage.',
+                },
+              ],
             },
           },
           {

--- a/cli/src/validation/ProjectContentValidator.spec.ts
+++ b/cli/src/validation/ProjectContentValidator.spec.ts
@@ -62,8 +62,6 @@ presentation:
       title: Roadmap
       content:
         stage: completed
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View roadmap
         stages:
           completed:
@@ -78,11 +76,15 @@ presentation:
           future:
             label: Future
             summary: Later
-        items:
-          - One
-        themes:
-          - category: Theme
-            target: Target
+        sections:
+          - title: Key deliverables
+            type: richtext
+            body: One
+          - title: Focus areas
+            type: keyvalue
+            body:
+              - key: Theme
+                value: Target
 `)
   await writeFile(resolve(root, 'content', 'presentations', 'demo', 'generated.yaml'), `
 schemaVersion: 1

--- a/content/presentations/2025-template-sparse/presentation.yaml
+++ b/content/presentations/2025-template-sparse/presentation.yaml
@@ -41,11 +41,13 @@ presentation:
           future:
             label: Future
             summary: Later
-        items:
-          - One
-        themes:
-          - category: Theme
-            target: Target
+        sections:
+          - type: richtext
+            body: One
+          - type: keyvalue
+            body:
+              - key: Theme
+                value: Target
     - template: people
       enabled: true
       title: Contributors

--- a/content/presentations/2026-q1/presentation.yaml
+++ b/content/presentations/2026-q1/presentation.yaml
@@ -71,11 +71,7 @@ presentation:
       title: "Roadmap: Completed"
       content:
         stage: completed
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View full roadmap & milestones on GitHub
-        item_fa_icon: fa-check
-        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -88,25 +84,31 @@ presentation:
             label: Planned
             summary: The published roadmap shifts next-step planning toward enterprise readiness, better UX, and automation-friendly
               workflows.
-        items:
-          - Reusable briefing templates landed for roadmap, release, and community updates.
-          - Aurora Notes' content manifest gained clearer publication metadata.
-          - Starter examples now cover weekly notes, planning reviews, and decision logs.
-          - Preview and archive fixes landed for nested routes, ordering, and template visibility.
-        themes:
-          - category: Team Readiness
-            target: Templates and preview fixes continue to make Aurora Notes easier for teams to adopt.
-          - category: Publishing Flow
-            target: Archive ordering and nested routes improved compatibility with static hosting workflows.
-          - category: Authoring Quality
-            target: Validation and empty-state updates reduced friction in day-to-day editing.
+        sections:
+          - title: Key deliverables
+            fa_icon: fa-check
+            type: richtext
+            body: |-
+              - Reusable briefing templates landed for roadmap, release, and community updates.
+              - Aurora Notes' content manifest gained clearer publication metadata.
+              - Starter examples now cover weekly notes, planning reviews, and decision logs.
+              - Preview and archive fixes landed for nested routes, ordering, and template visibility.
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Team Readiness
+                value: Templates and preview fixes continue to make Aurora Notes easier for teams to adopt.
+              - key: Publishing Flow
+                value: Archive ordering and nested routes improved compatibility with static hosting workflows.
+              - key: Authoring Quality
+                value: Validation and empty-state updates reduced friction in day-to-day editing.
     - template: progress-timeline
       enabled: true
       title: "Roadmap: In Progress"
       content:
         stage: in-progress
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View full roadmap & milestones on GitHub
         stages:
           completed:
@@ -123,25 +125,35 @@ presentation:
           future:
             label: Future
             summary: Version 3.x remains centered on a more interoperable file format and long-horizon project maturity goals.
-        items:
-          - Presentation search coverage and keyboard navigation coverage both landed in March.
-          - Documentation cleanup continued with dependency updates, template example fixes, and contributor guidance changes.
-          - Workflow and dependency maintenance continued across CI actions and build assets.
-          - The public planning board opened on March 8 to align future work under shared themes.
-        themes:
-          - category: Maintainability
-            target: Testing coverage, dependency hygiene, and build cleanup remain active themes.
-          - category: Community Confidence
-            target: Contributor guidance and documentation are being tightened as the project grows.
-          - category: Release Notes
-            target: Release-readiness work continued even without a tagged GitHub release in the window.
+        sections:
+          - title: Key deliverables
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: >-
+              - Presentation search coverage and keyboard navigation coverage both landed in March.
+
+              - Documentation cleanup continued with dependency updates, template example fixes, and contributor
+              guidance changes.
+
+              - Workflow and dependency maintenance continued across CI actions and build assets.
+
+              - The public planning board opened on March 8 to align future work under shared themes.
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Maintainability
+                value: Testing coverage, dependency hygiene, and build cleanup remain active themes.
+              - key: Community Confidence
+                value: Contributor guidance and documentation are being tightened as the project grows.
+              - key: Release Notes
+                value: Release-readiness work continued even without a tagged GitHub release in the window.
     - template: progress-timeline
       enabled: true
       title: "Roadmap: Planned"
       content:
         stage: planned
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View full roadmap & milestones on GitHub
         stages:
           completed:
@@ -158,25 +170,31 @@ presentation:
           future:
             label: Future
             summary: Version 3.x remains centered on a more interoperable file format and long-horizon project maturity goals.
-        items:
-          - Workspace presets, review checklists, and project templates remain part of the team-readiness backlog.
-          - Content catalogs, authoring guides, and CLI preview polish are called out as future deliverables.
-          - UX work includes search ergonomics, WCAG accessibility baselines, and a UI style guide.
-          - Export options, preview hooks, and publishing workflows are listed under automation.
-        themes:
-          - category: Team Readiness
-            target: Support team adoption without abandoning Git-based workflows.
-          - category: UX & Accessibility
-            target: Improve approachability, consistency, and accessibility across the product.
-          - category: Automation & Integration
-            target: Make Aurora Notes easier to connect to publishing workflows and tooling.
+        sections:
+          - title: Key deliverables
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Workspace presets, review checklists, and project templates remain part of the team-readiness backlog.
+              - Content catalogs, authoring guides, and CLI preview polish are called out as future deliverables.
+              - UX work includes search ergonomics, WCAG accessibility baselines, and a UI style guide.
+              - Export options, preview hooks, and publishing workflows are listed under automation.
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Team Readiness
+                value: Support team adoption without abandoning Git-based workflows.
+              - key: UX & Accessibility
+                value: Improve approachability, consistency, and accessibility across the product.
+              - key: Automation & Integration
+                value: Make Aurora Notes easier to connect to publishing workflows and tooling.
     - template: progress-timeline
       enabled: true
       title: "Roadmap: Future"
       content:
         stage: future
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View full roadmap & milestones on GitHub
         stages:
           completed:
@@ -193,18 +211,26 @@ presentation:
           future:
             label: Future
             summary: Version 3.x remains centered on a more interoperable file format and long-horizon project maturity goals.
-        items:
-          - Version 3.x is expected to move toward reusable content packages instead of one-off decks.
-          - Portable metadata is the likely direction for the future project manifest.
-          - The project page explicitly calls out integrations with adjacent publishing tools.
-          - The long-horizon roadmap also aims for a stable template marketplace.
-        themes:
-          - category: Portable Metadata
-            target: Center authored updates around reusable project data and interchange.
-          - category: Publishing Ecosystem
-            target: Reduce friction between Aurora Notes and other open-source publishing tools.
-          - category: Project Maturity
-            target: Continue the path from Demo Lab toward stable-template maturity.
+        sections:
+          - title: Key deliverables
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Version 3.x is expected to move toward reusable content packages instead of one-off decks.
+              - Portable metadata is the likely direction for the future project manifest.
+              - The project page explicitly calls out integrations with adjacent publishing tools.
+              - The long-horizon roadmap also aims for a stable template marketplace.
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Portable Metadata
+                value: Center authored updates around reusable project data and interchange.
+              - key: Publishing Ecosystem
+                value: Reduce friction between Aurora Notes and other open-source publishing tools.
+              - key: Project Maturity
+                value: Continue the path from Demo Lab toward stable-template maturity.
     - template: people
       enabled: true
       title: Contributor Spotlight
@@ -256,8 +282,8 @@ presentation:
             url_label: View the project page
             url: https://example.org/projects/aurora-notes/
           - type: Documentation
-            title: The version 2 documentation continues to cover configuration, templates, testing, and content metadata for current
-              users and contributors.
+            title: The version 2 documentation continues to cover configuration, templates, testing, and content metadata for
+              current users and contributors.
             url_label: Browse the docs
             url: https://docs.example.org/aurora-notes
     - template: image-and-bullets
@@ -301,8 +327,8 @@ presentation:
         cards:
           - title: Report Bugs
             fa_icon: fa-bug
-            description: File a reproducible issue with environment details, screenshots, and any project or stack context that helps
-              maintainers confirm the problem.
+            description: File a reproducible issue with environment details, screenshots, and any project or stack context that
+              helps maintainers confirm the problem.
             url_label: Submit an issue
             url: https://github.com/example-org/aurora-notes/issues
           - title: Submit Code

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -58,7 +58,7 @@ description: |-
 
 This is intentionally not full Markdown. Inline formatting, links, headings, tables, and raw HTML are treated as plain text. The renderer uses normal Vue text interpolation, so HTML-like input is escaped instead of injected into the page.
 
-Use lightweight rich text for body-copy fields such as action-card descriptions and footer text, people spotlight summaries, progress-timeline stage summaries and theme targets, shared list items, key-value row values, image descriptions, and closing messages. One-line strings continue to render as normal body copy.
+Use lightweight rich text for body-copy fields such as action-card descriptions and footer text, people spotlight summaries, progress-timeline stage summaries and section bodies, shared list items, key-value row values, image descriptions, and closing messages. One-line strings continue to render as normal body copy.
 
 ## Connectors
 

--- a/docs/fixtures/reference-project/content/presentations/2026-spring-briefing/presentation.yaml
+++ b/docs/fixtures/reference-project/content/presentations/2026-spring-briefing/presentation.yaml
@@ -67,11 +67,7 @@ presentation:
       subtitle: Delivered work
       content:
         stage: completed
-        deliverables_heading: Key deliverables
-        focus_areas_heading: Focus areas
         footer_link_label: View roadmap on GitHub
-        item_fa_icon: fa-check
-        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -85,15 +81,23 @@ presentation:
           future:
             label: Future
             summary: Longer-term work that depends on the current architecture pass.
-        items:
-          - Published a new starter kit for customer launch checklists.
-          - Added exportable PDF summaries for customer-facing review decks.
-          - Reworked the deployment checklist UI for operators.
-        themes:
-          - category: Operator UX
-            target: Make release review and launch readiness easier to audit.
-          - category: Exportability
-            target: Support polished handoff artifacts without manual cleanup.
+        sections:
+          - title: Key deliverables
+            fa_icon: fa-check
+            type: richtext
+            body: |-
+              - Published a new starter kit for customer launch checklists.
+              - Added exportable PDF summaries for customer-facing review decks.
+              - Reworked the deployment checklist UI for operators.
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Operator UX
+                value: Make release review and launch readiness easier to audit.
+              - key: Exportability
+                value: Support polished handoff artifacts without manual cleanup.
     - template: people
       enabled: true
       title: Contributor spotlight

--- a/docs/schema/presentation.md
+++ b/docs/schema/presentation.md
@@ -32,34 +32,29 @@ presentation:
 
 ## Progress timeline slide content
 
-The [progress-timeline](/templates/progress-timeline) template is self-contained. The slide owns its stage strip, active-stage detail, and footer labels.
+The [progress-timeline](/templates/progress-timeline) template is self-contained. The slide owns its stage strip, active-stage detail sections, and footer labels.
 
 | Field | Required | Type |
 | --- | --- | --- |
 | `content.stage` | yes | string |
-| `content.deliverables_heading` | | string |
-| `content.focus_areas_heading` | | string |
 | `content.footer_link_label` | | string |
-| `content.item_fa_icon` | | string |
-| `content.focus_areas_fa_icon` | | string |
-| `content.theme_fa_icon` | | string |
 | `content.footer_link_fa_icon` | | string |
 | `content.stages` | yes | object |
-| `content.items` | yes | string[] |
-| `content.themes` | yes | array of `{ category, target }` |
+| `content.sections` | yes | array of section objects |
 
-Stage summaries, item text, and theme targets support lightweight rich text.
+Stage summaries, rich-text section bodies, and key/value row values support lightweight rich text.
 
 ### `content.stages`
 
-Must contain exactly four keys:
+Must contain 2 to 6 entries. Stage keys are author-defined labels, such as:
 
-| Key | Required |
-| --- | --- |
-| `completed` | yes |
-| `in-progress` | yes |
-| `planned` | yes |
-| `future` | yes |
+| Example key |
+| --- |
+| `completed` |
+| `in-progress` |
+| `planned` |
+| `future` |
+| `6-months` |
 
 Each stage strip entry:
 
@@ -68,7 +63,17 @@ Each stage strip entry:
 | `label` | yes | string |
 | `summary` | yes | string |
 
-The active stage's `items` and `themes` live on the slide itself. Each `themes[]` entry has `category` (string, required) and `target` (string, required).
+### `content.sections`
+
+Must contain at least one and no more than three entries. Each section:
+
+| Field | Required | Type |
+| --- | --- | --- |
+| `title` | | string |
+| `fa_icon` | | string |
+| `type` | yes | `richtext` or `keyvalue` |
+| `body` | yes | string for `richtext`; array of `{ key, value }` for `keyvalue` |
+| `separator_fa_icon` | | string; only valid for `keyvalue` sections |
 
 ## Slides
 
@@ -155,16 +160,10 @@ Each `sections[]` entry may also set `fa_icon` to override its badge icon.
 | --- | --- | --- |
 | `title` | yes | |
 | `content.stage` | yes | Must match one key in `content.stages` |
-| `content.deliverables_heading` | | |
-| `content.focus_areas_heading` | | |
 | `content.footer_link_label` | | |
-| `content.item_fa_icon` | | Defaults to `fa-chevron-right` |
-| `content.focus_areas_fa_icon` | | Defaults to `fa-bullseye` |
-| `content.theme_fa_icon` | | Defaults to `fa-chevron-right` |
 | `content.footer_link_fa_icon` | | Defaults to `fa-github` |
 | `content.stages` | yes | 2 to 6 stage strip entries, rendered in authored order |
-| `content.items` | yes | Active stage items |
-| `content.themes` | yes | Active stage themes |
+| `content.sections` | yes | 1 to 3 active-stage sections |
 
 ### people
 

--- a/docs/templates/progress-timeline.md
+++ b/docs/templates/progress-timeline.md
@@ -1,6 +1,6 @@
 # Progress Timeline
 
-Focuses a single stage. Each slide carries its own stage headings and stage strip entries in `content`. The progress strip shows the authored stages in order; the detail columns use the slide's own `items` and `themes` for the active stage only.
+Focuses a single stage. Each slide carries its own stage strip entries and declarative detail sections in `content`. The progress strip shows the authored stages in order; the detail area renders one to three authored sections for the active stage.
 
 <figure class="template-doc-shot">
   <img src="/screenshots/template-progress-timeline-reference.png" alt="Progress timeline slide showing roadmap stages with the active stage expanded" />
@@ -17,12 +17,7 @@ Focuses a single stage. Each slide carries its own stage headings and stage stri
   subtitle: Current roadmap focus
   content:
     stage: 6-months
-    deliverables_heading: Key deliverables
-    focus_areas_heading: Focus areas
     footer_link_label: View roadmap on GitHub
-    item_fa_icon: fa-check
-    focus_areas_fa_icon: fa-bullseye
-    theme_fa_icon: fa-chevron-right
     footer_link_fa_icon: fa-github
     stages:
       3-months:
@@ -38,18 +33,28 @@ Focuses a single stage. Each slide carries its own stage headings and stage stri
       12-months:
         label: 12 Months
         summary: Scale the operating model.
-    items:
-      - Published a new starter kit for launch checklists.
-      - Added exportable PDF summaries.
-    themes:
-      - category: Operator UX
-        target: |-
-          Make release review easier to audit.
+    sections:
+      - title: Key deliverables
+        fa_icon: fa-check
+        type: richtext
+        body: |-
+          First paragraph.
 
-          - Preserve decisions
-          - Surface follow-ups
-      - category: Exportability
-        target: Support polished handoff artifacts.
+          - Published a new starter kit for launch checklists.
+          - Added exportable PDF summaries.
+      - title: Focus areas
+        fa_icon: fa-bullseye
+        type: keyvalue
+        separator_fa_icon: fa-chevron-right
+        body:
+          - key: Operator UX
+            value: |-
+              Make release review easier to audit.
+
+              - Preserve decisions
+              - Surface follow-ups
+          - key: Exportability
+            value: Support polished handoff artifacts.
 ```
 
 ## Data sources
@@ -58,8 +63,7 @@ Focuses a single stage. Each slide carries its own stage headings and stage stri
 | --- | --- |
 | Progress strip | All stages from `content.stages`; stage summaries support lightweight rich text |
 | Active stage highlight | Matches `content.stage` |
-| Deliverables column | `content.deliverables_heading` + `content.items` |
-| Focus areas column | `content.focus_areas_heading` + `content.themes`; theme targets support lightweight rich text |
+| Detail sections | `content.sections[]`, rendered in authored order |
 | Footer link | `content.footer_link_label` with href `site.links.repository.url` |
 
 If `subtitle` is omitted, the active stage's `summary` is used instead.
@@ -71,17 +75,23 @@ If `subtitle` is omitted, the active stage's `summary` is used instead.
 | `title` | yes | string | |
 | `subtitle` | | string | |
 | `content.stage` | yes | string | Must match one key in `content.stages` |
-| `content.deliverables_heading` | | string | |
-| `content.focus_areas_heading` | | string | |
 | `content.footer_link_label` | | string | |
-| `content.item_fa_icon` | | string | Defaults to `fa-chevron-right` |
-| `content.focus_areas_fa_icon` | | string | Defaults to `fa-bullseye` |
-| `content.theme_fa_icon` | | string | Defaults to `fa-chevron-right` |
 | `content.footer_link_fa_icon` | | string | Defaults to `fa-github` |
 | `content.stages` | yes | object | 2 to 6 stage strip entries, rendered in authored order |
-| `content.items` | yes | string[] | Active stage items; item text supports lightweight rich text |
-| `content.themes` | yes | array | Active stage themes; `target` supports lightweight rich text |
+| `content.sections` | yes | array | 1 to 3 active-stage sections |
 
-Stage keys may use the existing `completed`, `in-progress`, `planned`, and `future` shape, or custom labels such as `3-months`, `6-months`, and `12-months`. Stage summaries, deliverable items, and theme targets accept the lightweight rich text documented in [Concepts](/concepts#lightweight-rich-text). The progress timeline schema is documented in [presentation.yaml](/schema/presentation#progress-timeline).
+### `content.sections[]`
+
+| Field | Required | Type | Values |
+| --- | --- | --- | --- |
+| `title` | | string | Section heading |
+| `fa_icon` | | string | Heading icon |
+| `type` | yes | string | `richtext` or `keyvalue` |
+| `body` | yes | string or array | Shape depends on `type` |
+| `separator_fa_icon` | | string | Key/value row separator icon; only valid when `type` is `keyvalue` |
+
+For `type: richtext`, `body` is a lightweight rich-text string. For `type: keyvalue`, `body` is an array of `{ key, value }` rows, and each `value` supports lightweight rich text.
+
+Stage keys may use the existing `completed`, `in-progress`, `planned`, and `future` shape, or custom labels such as `3-months`, `6-months`, and `12-months`. Stage summaries, rich-text section bodies, and key/value row values accept the lightweight rich text documented in [Concepts](/concepts#lightweight-rich-text). The progress timeline schema is documented in [presentation.yaml](/schema/presentation#progress-timeline).
 
 Icon fields use supported values from the [Font Awesome icon reference](/reference/fontawesome).

--- a/examples/community-update/content/presentations/2026-q1-community/presentation.yaml
+++ b/examples/community-update/content/presentations/2026-q1-community/presentation.yaml
@@ -58,8 +58,6 @@ presentation:
       subtitle: Community initiatives delivered
       content:
         stage: completed
-        deliverables_heading: Delivered
-        focus_areas_heading: Themes
         footer_link_label: View community roadmap
         stages:
           completed:
@@ -74,15 +72,23 @@ presentation:
           future:
             label: Future
             summary: Exploring for later in the year.
-        items:
-          - Launched 3 new learning paths on the developer portal
-          - Spoke at 4 conferences across 3 countries
-          - Shipped the community SDK with 15 code samples
-        themes:
-          - category: Education
-            target: Lower the barrier to entry for new developers.
-          - category: Reach
-            target: Grow awareness in new geographic markets.
+        sections:
+          - title: Delivered
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Launched 3 new learning paths on the developer portal
+              - Spoke at 4 conferences across 3 countries
+              - Shipped the community SDK with 15 code samples
+          - title: Themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Education
+                value: Lower the barrier to entry for new developers.
+              - key: Reach
+                value: Grow awareness in new geographic markets.
     - template: people
       enabled: true
       title: Community champions

--- a/examples/open-source-update/content/presentations/2026-q1-update/presentation.yaml
+++ b/examples/open-source-update/content/presentations/2026-q1-update/presentation.yaml
@@ -63,11 +63,7 @@ presentation:
       subtitle: What we shipped
       content:
         stage: completed
-        deliverables_heading: Shipped
-        focus_areas_heading: Themes
         footer_link_label: View full roadmap
-        item_fa_icon: fa-check
-        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -81,15 +77,23 @@ presentation:
           future:
             label: Future
             summary: Under discussion.
-        items:
-          - Plugin system with local and registry-based resolution
-          - Structured error messages with fix suggestions
-          - Shell completion for bash, zsh, and fish
-        themes:
-          - category: Extensibility
-            target: Let users add functionality without forking.
-          - category: Developer Experience
-            target: Reduce time-to-fix for common errors.
+        sections:
+          - title: Shipped
+            fa_icon: fa-check
+            type: richtext
+            body: |-
+              - Plugin system with local and registry-based resolution
+              - Structured error messages with fix suggestions
+              - Shell completion for bash, zsh, and fish
+          - title: Themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Extensibility
+                value: Let users add functionality without forking.
+              - key: Developer Experience
+                value: Reduce time-to-fix for common errors.
     - template: people
       enabled: true
       title: Contributor spotlight

--- a/examples/product-review/content/presentations/2026-q1-review/presentation.yaml
+++ b/examples/product-review/content/presentations/2026-q1-review/presentation.yaml
@@ -58,8 +58,6 @@ presentation:
       subtitle: Q1 deliverables
       content:
         stage: completed
-        deliverables_heading: Delivered
-        focus_areas_heading: Strategic themes
         footer_link_label: View full roadmap
         stages:
           completed:
@@ -74,15 +72,23 @@ presentation:
           future:
             label: Future
             summary: Under exploration.
-        items:
-          - Workspace redesign with customizable layouts
-          - API v3 with breaking change migration tool
-          - Self-serve onboarding flow for teams under 50
-        themes:
-          - category: User Experience
-            target: Reduce time-to-value for new workspace setups.
-          - category: Platform
-            target: Modernize the API for partner integrations.
+        sections:
+          - title: Delivered
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Workspace redesign with customizable layouts
+              - API v3 with breaking change migration tool
+              - Self-serve onboarding flow for teams under 50
+          - title: Strategic themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: User Experience
+                value: Reduce time-to-value for new workspace setups.
+              - key: Platform
+                value: Modernize the API for partner integrations.
     - template: people
       enabled: true
       title: Team spotlight

--- a/examples/security-posture/content/presentations/2026-q1-posture/presentation.yaml
+++ b/examples/security-posture/content/presentations/2026-q1-posture/presentation.yaml
@@ -57,8 +57,6 @@ presentation:
       subtitle: Q1 security initiatives
       content:
         stage: completed
-        deliverables_heading: Completed initiatives
-        focus_areas_heading: Focus areas
         footer_link_label: View security roadmap
         stages:
           completed:
@@ -73,15 +71,23 @@ presentation:
           future:
             label: Future
             summary: Under evaluation.
-        items:
-          - Migrated all services to automated dependency scanning
-          - Completed annual penetration test with zero critical findings
-          - Rolled out hardware security keys for all engineering staff
-        themes:
-          - category: Supply Chain
-            target: Eliminate unscanned dependencies from production.
-          - category: Authentication
-            target: Phishing-resistant credentials for all engineers.
+        sections:
+          - title: Completed initiatives
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Migrated all services to automated dependency scanning
+              - Completed annual penetration test with zero critical findings
+              - Rolled out hardware security keys for all engineering staff
+          - title: Focus areas
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Supply Chain
+                value: Eliminate unscanned dependencies from production.
+              - key: Authentication
+                value: Phishing-resistant credentials for all engineers.
     - template: people
       enabled: true
       title: Security team

--- a/shared/src/json-schema.spec.ts
+++ b/shared/src/json-schema.spec.ts
@@ -262,14 +262,59 @@ describe('public JSON Schemas', () => {
               '6-months': { label: '6 Months', summary: 'Expand core workflows.' },
               '12-months': { label: '12 Months', summary: 'Scale the operating model.' },
             },
-            items: ['Measure adoption'],
-            themes: [{ category: 'Adoption', target: 'Make progress explicit' }],
+            sections: [
+              {
+                title: 'What happened',
+                fa_icon: 'fa-check',
+                type: 'richtext',
+                body: 'Measure adoption',
+              },
+              {
+                title: 'Signals',
+                fa_icon: 'fa-bullseye',
+                type: 'keyvalue',
+                separator_fa_icon: 'fa-arrow-right',
+                body: [{ key: 'Adoption', value: 'Make progress explicit' }],
+              },
+            ],
           },
         }],
       },
     }
 
     expect(validateDocument(ajv, schemaIds.presentation, document)).toEqual([])
+  })
+
+  it('rejects progress-timeline rich text sections with separator icons', async () => {
+    const ajv = await loadSchemas()
+    const document = {
+      schemaVersion: 1,
+      presentation: {
+        id: 'demo',
+        title: 'Demo',
+        subtitle: 'Example',
+        slides: [{
+          template: 'progress-timeline',
+          enabled: true,
+          title: 'Roadmap',
+          content: {
+            stage: '6-months',
+            stages: {
+              '3-months': { label: '3 Months', summary: 'Stabilize adoption.' },
+              '6-months': { label: '6 Months', summary: 'Expand core workflows.' },
+              '12-months': { label: '12 Months', summary: 'Scale the operating model.' },
+            },
+            sections: [{
+              type: 'richtext',
+              separator_fa_icon: 'fa-arrow-right',
+              body: 'Measure adoption',
+            }],
+          },
+        }],
+      },
+    }
+
+    expect(validateDocument(ajv, schemaIds.presentation, document).length).toBeGreaterThan(0)
   })
 
   it('accepts action-cards slides with informational cards and a disabled footer link', async () => {
@@ -419,8 +464,10 @@ describe('public JSON Schemas', () => {
             stages: {
               completed: { label: 'Completed', summary: 'Delivered work.' },
             },
-            items: ['Measure adoption'],
-            themes: [{ category: 'Adoption', target: 'Make progress explicit' }],
+            sections: [{
+              type: 'richtext',
+              body: 'Measure adoption',
+            }],
           },
         }],
       },

--- a/shared/src/templates/progress-timeline-validation.spec.ts
+++ b/shared/src/templates/progress-timeline-validation.spec.ts
@@ -12,8 +12,20 @@ const validProgressTimelineSlide = {
       planned: { label: 'Next', summary: 'Planned work' },
       future: { label: 'Later', summary: 'Future work' },
     },
-    items: ['Ship it'],
-    themes: [{ category: 'Quality', target: 'Keep gates green' }],
+    sections: [
+      {
+        title: 'What changed',
+        fa_icon: 'fa-check',
+        type: 'richtext',
+        body: 'Ship it',
+      },
+      {
+        title: 'Signals',
+        type: 'keyvalue',
+        separator_fa_icon: 'fa-arrow-right',
+        body: [{ key: 'Quality', value: 'Keep gates green' }],
+      },
+    ],
   },
 } as const
 
@@ -100,5 +112,64 @@ describe('progress-timeline validation', () => {
         'slides[progress]',
       ),
     ).toThrow('slides[progress].content.stages must include no more than 6 stages.')
+  })
+
+  it('rejects more than three declarative sections', () => {
+    expect(() =>
+      validateTemplateSlide(
+        'progress-timeline',
+        {
+          ...validProgressTimelineSlide,
+          content: {
+            ...validProgressTimelineSlide.content,
+            sections: [
+              { type: 'richtext', body: 'One' },
+              { type: 'richtext', body: 'Two' },
+              { type: 'richtext', body: 'Three' },
+              { type: 'richtext', body: 'Four' },
+            ],
+          },
+        },
+        'slides[progress]',
+      ),
+    ).toThrow('slides[progress].content.sections must include no more than 3 sections.')
+  })
+
+  it('rejects separator icons for richtext sections', () => {
+    expect(() =>
+      validateTemplateSlide(
+        'progress-timeline',
+        {
+          ...validProgressTimelineSlide,
+          content: {
+            ...validProgressTimelineSlide.content,
+            sections: [
+              {
+                type: 'richtext',
+                separator_fa_icon: 'fa-arrow-right',
+                body: 'Text',
+              },
+            ],
+          },
+        },
+        'slides[progress]',
+      ),
+    ).toThrow('slides[progress].content.sections[0].separator_fa_icon is only allowed when slides[progress].content.sections[0].type is "keyvalue".')
+  })
+
+  it('rejects unsupported detail fields', () => {
+    expect(() =>
+      validateTemplateSlide(
+        'progress-timeline',
+        {
+          ...validProgressTimelineSlide,
+          content: {
+            ...validProgressTimelineSlide.content,
+            detail_columns: ['Fixed detail'],
+          },
+        },
+        'slides[progress]',
+      ),
+    ).toThrow('slides[progress].content.detail_columns is not allowed.')
   })
 })

--- a/shared/src/templates/validation.spec.ts
+++ b/shared/src/templates/validation.spec.ts
@@ -13,16 +13,24 @@ const validProgressTimelineSlide = {
   title: 'Progress',
   content: {
     stage: 'planned',
-    deliverables_heading: 'Deliverables',
-    focus_areas_heading: 'Focus',
     footer_link_label: 'Roadmap',
-    item_fa_icon: 'fa-chevron-right',
-    focus_areas_fa_icon: 'fa-bullseye',
-    theme_fa_icon: 'fa-check',
     footer_link_fa_icon: 'fa-github',
     stages: validRoadmapStages,
-    items: ['Ship it'],
-    themes: [{ category: 'Quality', target: 'Keep gates green' }],
+    sections: [
+      {
+        title: 'Details',
+        fa_icon: 'fa-chevron-right',
+        type: 'richtext',
+        body: 'Ship it',
+      },
+      {
+        title: 'Signals',
+        fa_icon: 'fa-bullseye',
+        type: 'keyvalue',
+        separator_fa_icon: 'fa-check',
+        body: [{ key: 'Quality', value: 'Keep gates green' }],
+      },
+    ],
   },
 } as const
 

--- a/shared/src/templates/validation.ts
+++ b/shared/src/templates/validation.ts
@@ -45,17 +45,42 @@ function assertRoadmapStages(value: unknown, activeStage: unknown, path: string)
   )
 }
 
-function assertRoadmapTheme(value: unknown, path: string): void {
+function assertProgressTimelineKeyValueRow(value: unknown, path: string): void {
   assert(isRecord(value), `${path} must be an object.`)
-  assertNonBlankString(value.category, `${path}.category`)
-  assertNonBlankString(value.target, `${path}.target`)
+  assertNoUnexpectedKeys(value, ['key', 'value'], path)
+  assertNonBlankString(value.key, `${path}.key`)
+  assertNonBlankString(value.value, `${path}.value`)
 }
 
-function assertRoadmapThemes(value: unknown, path: string): void {
+function assertProgressTimelineSection(value: unknown, path: string): void {
+  assert(isRecord(value), `${path} must be an object.`)
+  assertNoUnexpectedKeys(value, ['title', 'fa_icon', 'type', 'separator_fa_icon', 'body'], path)
+  assertOptionalString(value.title, `${path}.title`)
+  assertOptionalFontAwesomeIcon(value.fa_icon, `${path}.fa_icon`)
+
+  if (value.type === 'richtext') {
+    assertNonBlankString(value.body, `${path}.body`)
+    assert(
+      value.separator_fa_icon === undefined,
+      `${path}.separator_fa_icon is only allowed when ${path}.type is "keyvalue".`,
+    )
+    return
+  }
+
+  assert(value.type === 'keyvalue', `${path}.type must be "richtext" or "keyvalue".`)
+  assertOptionalFontAwesomeIcon(value.separator_fa_icon, `${path}.separator_fa_icon`)
+  assert(Array.isArray(value.body), `${path}.body must be an array.`)
+  ;(value.body as unknown[]).forEach((row, index) => {
+    assertProgressTimelineKeyValueRow(row, `${path}.body[${index}]`)
+  })
+}
+
+function assertProgressTimelineSections(value: unknown, path: string): void {
   assert(Array.isArray(value), `${path} must be an array.`)
-  ;(value as unknown[]).forEach((theme, index) => {
-    assert(isRecord(theme), `${path}[${index}] must be an object.`)
-    assertRoadmapTheme(theme, `${path}[${index}]`)
+  assert(value.length >= 1, `${path} must include at least 1 section.`)
+  assert(value.length <= 3, `${path} must include no more than 3 sections.`)
+  value.forEach((section, index) => {
+    assertProgressTimelineSection(section, `${path}[${index}]`)
   })
 }
 
@@ -212,29 +237,17 @@ const progressTimelineValidator: SlideTemplateValidator = (slide, path) => {
     content,
     [
       'stage',
-      'deliverables_heading',
-      'focus_areas_heading',
+      'sections',
       'footer_link_label',
       'stages',
-      'items',
-      'themes',
-      'item_fa_icon',
-      'focus_areas_fa_icon',
-      'theme_fa_icon',
       'footer_link_fa_icon',
     ],
     `${path}.content`,
   )
-  assertOptionalString(content.deliverables_heading, `${path}.content.deliverables_heading`)
-  assertOptionalString(content.focus_areas_heading, `${path}.content.focus_areas_heading`)
   assertOptionalString(content.footer_link_label, `${path}.content.footer_link_label`)
-  assertOptionalFontAwesomeIcon(content.item_fa_icon, `${path}.content.item_fa_icon`)
-  assertOptionalFontAwesomeIcon(content.focus_areas_fa_icon, `${path}.content.focus_areas_fa_icon`)
-  assertOptionalFontAwesomeIcon(content.theme_fa_icon, `${path}.content.theme_fa_icon`)
   assertOptionalFontAwesomeIcon(content.footer_link_fa_icon, `${path}.content.footer_link_fa_icon`)
   assertRoadmapStages(content.stages, content.stage, `${path}.content`)
-  assertStringArray(content.items, `${path}.content.items`)
-  assertRoadmapThemes(content.themes, `${path}.content.themes`)
+  assertProgressTimelineSections(content.sections, `${path}.content.sections`)
 }
 
 const peopleValidator: SlideTemplateValidator = (slide, path) => {

--- a/slides/content/presentations/2025-community-update-example/presentation.yaml
+++ b/slides/content/presentations/2025-community-update-example/presentation.yaml
@@ -55,8 +55,6 @@ presentation:
       subtitle: Community initiatives delivered
       content:
         stage: completed
-        deliverables_heading: Delivered
-        focus_areas_heading: Themes
         footer_link_label: View community roadmap
         stages:
           completed:
@@ -71,15 +69,23 @@ presentation:
           future:
             label: Future
             summary: Exploring for later in the year.
-        items:
-          - Launched 3 new learning paths on the developer portal
-          - Spoke at 4 conferences across 3 countries
-          - Shipped the community SDK with 15 code samples
-        themes:
-          - category: Education
-            target: Lower the barrier to entry for new developers.
-          - category: Reach
-            target: Grow awareness in new geographic markets.
+        sections:
+          - title: Delivered
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Launched 3 new learning paths on the developer portal
+              - Spoke at 4 conferences across 3 countries
+              - Shipped the community SDK with 15 code samples
+          - title: Themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Education
+                value: Lower the barrier to entry for new developers.
+              - key: Reach
+                value: Grow awareness in new geographic markets.
     - template: people
       enabled: true
       title: Community champions

--- a/slides/content/presentations/2025-open-source-example/presentation.yaml
+++ b/slides/content/presentations/2025-open-source-example/presentation.yaml
@@ -68,11 +68,7 @@ presentation:
       subtitle: What we shipped
       content:
         stage: completed
-        deliverables_heading: Shipped
-        focus_areas_heading: Themes
         footer_link_label: View full roadmap
-        item_fa_icon: fa-check
-        focus_areas_fa_icon: fa-bullseye
         stages:
           completed:
             label: Completed
@@ -83,15 +79,23 @@ presentation:
           planned:
             label: Planned
             summary: Scoped for Q2 2025.
-        items:
-          - Plugin system with local and registry-based resolution
-          - Structured error messages with fix suggestions
-          - Shell completion for bash, zsh, and fish
-        themes:
-          - category: Extensibility
-            target: Let users add functionality without forking.
-          - category: Developer Experience
-            target: Reduce time-to-fix for common errors.
+        sections:
+          - title: Shipped
+            fa_icon: fa-check
+            type: richtext
+            body: |-
+              - Plugin system with local and registry-based resolution
+              - Structured error messages with fix suggestions
+              - Shell completion for bash, zsh, and fish
+          - title: Themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Extensibility
+                value: Let users add functionality without forking.
+              - key: Developer Experience
+                value: Reduce time-to-fix for common errors.
     - template: people
       enabled: true
       title: Contributor spotlight

--- a/slides/content/presentations/2026-launch/presentation.yaml
+++ b/slides/content/presentations/2026-launch/presentation.yaml
@@ -60,8 +60,6 @@ presentation:
       subtitle: Everything delivered in the launch sprint
       content:
         stage: completed
-        deliverables_heading: Delivered
-        focus_areas_heading: Themes
         footer_link_label: View full roadmap
         stages:
           completed:
@@ -76,27 +74,33 @@ presentation:
           future:
             label: Future
             summary: Longer-horizon ideas being explored.
-        items:
-          - Full built-in template set (hero through closing, including image-and-bullets)
-          - CLI with init, validate, fetch, build, serve
-          - Vue 3 app renderer with Vite
-          - Unit, E2E, a11y, and visual regression tests
-          - CI/CD with Semgrep, Trivy, and Gitleaks scanning
-          - OpenSSF Best Practices badge achieved
-          - VitePress documentation site
-        themes:
-          - category: Functionality
-            target: All table-stakes features for a usable v0.
-          - category: Quality
-            target: Ship with meaningful test coverage from day one.
+        sections:
+          - title: Delivered
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - Full built-in template set (hero through closing, including image-and-bullets)
+              - CLI with init, validate, fetch, build, serve
+              - Vue 3 app renderer with Vite
+              - Unit, E2E, a11y, and visual regression tests
+              - CI/CD with Semgrep, Trivy, and Gitleaks scanning
+              - OpenSSF Best Practices badge achieved
+              - VitePress documentation site
+          - title: Themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Functionality
+                value: All table-stakes features for a usable v0.
+              - key: Quality
+                value: Ship with meaningful test coverage from day one.
     - template: progress-timeline
       enabled: true
       title: "Roadmap: In Progress"
       subtitle: Active work right now
       content:
         stage: in-progress
-        deliverables_heading: In Progress
-        focus_areas_heading: Themes
         footer_link_label: View full roadmap
         stages:
           completed:
@@ -111,16 +115,24 @@ presentation:
           future:
             label: Future
             summary: Longer-horizon ideas being explored.
-        items:
-          - First stable release (v1.0.0)
-          - slide-spec.dev homepage (this site)
-          - docs.slide-spec.dev documentation site
-          - Usability & user acceptance testing
-        themes:
-          - category: Stability
-            target: Remove alpha-stage rough edges before the first real users.
-          - category: Visibility
-            target: Give the project a home on the web.
+        sections:
+          - title: In Progress
+            fa_icon: fa-chevron-right
+            type: richtext
+            body: |-
+              - First stable release (v1.0.0)
+              - slide-spec.dev homepage (this site)
+              - docs.slide-spec.dev documentation site
+              - Usability & user acceptance testing
+          - title: Themes
+            fa_icon: fa-bullseye
+            type: keyvalue
+            separator_fa_icon: fa-chevron-right
+            body:
+              - key: Stability
+                value: Remove alpha-stage rough edges before the first real users.
+              - key: Visibility
+                value: Give the project a home on the web.
     - template: metrics-and-links
       enabled: true
       title: Project health

--- a/slides/public/schema/defs.schema.json
+++ b/slides/public/schema/defs.schema.json
@@ -245,14 +245,44 @@
         "summary": { "$ref": "#/$defs/nonBlankString" }
       }
     },
-    "roadmapTheme": {
+    "progressTimelineKeyValueRow": {
       "type": "object",
-      "required": ["category", "target"],
+      "required": ["key", "value"],
       "additionalProperties": false,
       "properties": {
-        "category": { "$ref": "#/$defs/nonBlankString" },
-        "target": { "$ref": "#/$defs/nonBlankString" }
+        "key": { "$ref": "#/$defs/nonBlankString" },
+        "value": { "$ref": "#/$defs/nonBlankString" }
       }
+    },
+    "progressTimelineSection": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["type", "body"],
+          "additionalProperties": false,
+          "properties": {
+            "title": { "$ref": "#/$defs/nonBlankString" },
+            "fa_icon": { "$ref": "#/$defs/fontAwesomeIcon" },
+            "type": { "const": "richtext" },
+            "body": { "$ref": "#/$defs/nonBlankString" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "body"],
+          "additionalProperties": false,
+          "properties": {
+            "title": { "$ref": "#/$defs/nonBlankString" },
+            "fa_icon": { "$ref": "#/$defs/fontAwesomeIcon" },
+            "type": { "const": "keyvalue" },
+            "separator_fa_icon": { "$ref": "#/$defs/fontAwesomeIcon" },
+            "body": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/progressTimelineKeyValueRow" }
+            }
+          }
+        }
+      ]
     },
     "spotlightEntry": {
       "type": "object",

--- a/slides/public/schema/presentation.schema.json
+++ b/slides/public/schema/presentation.schema.json
@@ -221,16 +221,17 @@
             "template": { "const": "progress-timeline" },
             "content": {
               "type": "object",
-              "required": ["stage", "stages", "items", "themes"],
+              "required": ["stage", "stages", "sections"],
               "additionalProperties": false,
               "properties": {
                 "stage": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
-                "deliverables_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
-                "focus_areas_heading": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
+                "sections": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 3,
+                  "items": { "$ref": "defs.schema.json#/$defs/progressTimelineSection" }
+                },
                 "footer_link_label": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
-                "item_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
-                "focus_areas_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
-                "theme_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
                 "footer_link_fa_icon": { "$ref": "defs.schema.json#/$defs/fontAwesomeIcon" },
                 "stages": {
                   "type": "object",
@@ -238,11 +239,6 @@
                   "maxProperties": 6,
                   "propertyNames": { "$ref": "defs.schema.json#/$defs/nonBlankString" },
                   "additionalProperties": { "$ref": "defs.schema.json#/$defs/roadmapStage" }
-                },
-                "items": { "$ref": "defs.schema.json#/$defs/stringArray" },
-                "themes": {
-                  "type": "array",
-                  "items": { "$ref": "defs.schema.json#/$defs/roadmapTheme" }
                 }
               }
             }


### PR DESCRIPTION
## What

<!-- Brief description of what this PR does and why. -->
made progress-timeline template far more abstract
standardized names and decoupled from specific intent
You can now have 1-3 sections under the timeline

## Related issue

<!-- Link the issue this PR addresses. An issue is required before opening a PR. -->

Closes #176 


## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Other (describe below)

<!-- If selecting "Other", please describe the type of change -->

## Breaking changes

<!-- Does this PR introduce a breaking change? Slide Spec follows semver - breaking changes must be clearly documented. -->

- [x] Yes (describe below)
- [ ] No

Intentional alpha schema change

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes
