### PR TITLE
cli dev server now supports serving from root node_modules

### DIFF
--- a/cli/src/runtime/ViteSiteDevServer.spec.ts
+++ b/cli/src/runtime/ViteSiteDevServer.spec.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { ViteSiteDevServer } from './ViteSiteDevServer'
 
@@ -6,12 +10,14 @@ import type { AddressInfo } from 'node:net'
 import type { InlineConfig, ViteDevServer } from 'vite'
 
 class StubPackagePaths {
+  public constructor(private readonly packageRoot: string = '/cli') {}
+
   public getPackageRoot(): string {
-    return '/cli'
+    return this.packageRoot
   }
 
   public getNodeModulesRoot(): string {
-    return '/cli/node_modules'
+    return resolve(this.packageRoot, 'node_modules')
   }
 }
 
@@ -45,7 +51,19 @@ function createViteServerDouble(options: {
   } as unknown as ViteDevServer
 }
 
+const tempRoots: string[] = []
+
+async function createRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(resolve(tmpdir(), prefix))
+  tempRoots.push(root)
+  return root
+}
+
 describe('ViteSiteDevServer', () => {
+  afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+  })
+
   it('starts a Vite dev server with the live content workspace and returns the bound port', async () => {
     const packagePaths = new StubPackagePaths()
     const runtimeWorkspace = new StubRuntimeWorkspace()
@@ -80,6 +98,37 @@ describe('ViteSiteDevServer', () => {
       }),
     }))
     expect(runtimeWorkspace.cleanup).not.toHaveBeenCalled()
+  })
+
+  it('allows real node_modules package paths so pnpm-linked font assets can be served', async () => {
+    const cliRoot = await createRoot('slide-spec-cli-')
+    const realPackageRoot = await createRoot('slide-spec-poppins-')
+    await mkdir(resolve(cliRoot, 'node_modules', '@fontsource'), { recursive: true })
+    await symlink(
+      realPackageRoot,
+      resolve(cliRoot, 'node_modules', '@fontsource', 'poppins'),
+      'junction',
+    )
+
+    const viteServer = createViteServerDouble()
+    const createServer = vi.fn(async (_config) => viteServer)
+    const server = new ViteSiteDevServer(
+      new StubPackagePaths(cliRoot) as never,
+      new StubRuntimeWorkspace() as never,
+      createServer,
+    )
+
+    await expect(server.start({
+      getProjectRoot: () => '/project',
+    } as never, '127.0.0.1', 4173)).resolves.toBe(4173)
+
+    expect(createServer).toHaveBeenCalledWith(expect.objectContaining({
+      server: expect.objectContaining({
+        fs: {
+          allow: expect.arrayContaining([realPackageRoot]),
+        },
+      }),
+    }))
   })
 
   it('resolves port 0 to an explicit free port before starting Vite', async () => {

--- a/cli/src/runtime/ViteSiteDevServer.spec.ts
+++ b/cli/src/runtime/ViteSiteDevServer.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 
@@ -129,6 +129,59 @@ describe('ViteSiteDevServer', () => {
         },
       }),
     }))
+  })
+
+  it('deduplicates allowed package realpaths and ignores non-package node_modules entries', async () => {
+    const cliRoot = await createRoot('slide-spec-cli-')
+    const realPackageRoot = await createRoot('slide-spec-shared-package-')
+    const realUnscopedPackageRoot = await createRoot('slide-spec-unscoped-package-')
+    const nodeModulesRoot = resolve(cliRoot, 'node_modules')
+    await mkdir(resolve(nodeModulesRoot, '@fontsource'), { recursive: true })
+    await symlink(
+      realPackageRoot,
+      resolve(nodeModulesRoot, '@fontsource', 'poppins'),
+      'junction',
+    )
+    await symlink(
+      realPackageRoot,
+      resolve(nodeModulesRoot, '@fontsource', 'roboto-mono'),
+      'junction',
+    )
+    await symlink(
+      realUnscopedPackageRoot,
+      resolve(nodeModulesRoot, 'vite'),
+      'junction',
+    )
+    await symlink(
+      resolve(cliRoot, 'missing-scope-target'),
+      resolve(nodeModulesRoot, '@missing'),
+      'junction',
+    )
+    await symlink(
+      resolve(cliRoot, 'missing-package-target'),
+      resolve(nodeModulesRoot, 'missing-package'),
+      'junction',
+    )
+    await writeFile(resolve(nodeModulesRoot, '.modules.yaml'), 'ignored: true')
+
+    const viteServer = createViteServerDouble()
+    const createServer = vi.fn(async (_config) => viteServer)
+    const server = new ViteSiteDevServer(
+      new StubPackagePaths(cliRoot) as never,
+      new StubRuntimeWorkspace() as never,
+      createServer,
+    )
+
+    await expect(server.start({
+      getProjectRoot: () => cliRoot,
+    } as never, '127.0.0.1', 4173)).resolves.toBe(4173)
+
+    const allow = (createServer.mock.calls[0]?.[0].server?.fs?.allow ?? []) as string[]
+    expect(allow).toContain(realPackageRoot)
+    expect(allow).toContain(realUnscopedPackageRoot)
+    expect(allow.filter((path) => path === realPackageRoot)).toHaveLength(1)
+    expect(allow).not.toContain(resolve(cliRoot, 'missing-scope-target'))
+    expect(allow).not.toContain(resolve(cliRoot, 'missing-package-target'))
   })
 
   it('resolves port 0 to an explicit free port before starting Vite', async () => {

--- a/cli/src/runtime/ViteSiteDevServer.ts
+++ b/cli/src/runtime/ViteSiteDevServer.ts
@@ -1,3 +1,4 @@
+import { opendir, realpath } from 'node:fs/promises'
 import { createServer as createNetServer } from 'node:net'
 import { resolve } from 'node:path'
 
@@ -7,7 +8,7 @@ import vue from '@vitejs/plugin-vue'
 import { createServer as viteCreateServer } from 'vite'
 
 import { CliPackagePaths } from './CliPackagePaths'
-import { RuntimeWorkspace } from './RuntimeWorkspace'
+import { RuntimeWorkspace, type PreparedRuntimeWorkspace } from './RuntimeWorkspace'
 
 import type { FileSystemPaths } from '../io/FileSystemPaths'
 import type { ViteDevServer, InlineConfig } from 'vite'
@@ -26,6 +27,7 @@ export class ViteSiteDevServer {
 
     try {
       const resolvedPort = port === 0 ? await this.findFreePort(host) : port
+      const filesystemAllow = await this.resolveFilesystemAllow(workspace, paths)
       const server = await this.createViteServer({
         appType: 'spa',
         root: workspace.appRoot,
@@ -48,12 +50,7 @@ export class ViteSiteDevServer {
           strictPort: true,
           open: false,
           fs: {
-            allow: [
-              workspace.root,
-              paths.getProjectRoot(),
-              this.packagePaths.getPackageRoot(),
-              this.packagePaths.getNodeModulesRoot(),
-            ],
+            allow: filesystemAllow,
           },
         },
       })
@@ -80,6 +77,72 @@ export class ViteSiteDevServer {
     }
 
     return address.port
+  }
+
+  private async resolveFilesystemAllow(workspace: PreparedRuntimeWorkspace, paths: FileSystemPaths): Promise<string[]> {
+    return [
+      workspace.root,
+      paths.getProjectRoot(),
+      this.packagePaths.getPackageRoot(),
+      this.packagePaths.getNodeModulesRoot(),
+      ...await this.resolveNodeModuleRealpaths(),
+    ].filter((path, index, allPaths) => allPaths.indexOf(path) === index)
+  }
+
+  private async resolveNodeModuleRealpaths(): Promise<string[]> {
+    const nodeModulesRoot = this.packagePaths.getNodeModulesRoot()
+    const packageRoots: string[] = []
+
+    try {
+      for await (const entry of await opendir(nodeModulesRoot)) {
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+          continue
+        }
+
+        if (entry.name.startsWith('@')) {
+          packageRoots.push(...await this.resolveScopedPackageRealpaths(resolve(nodeModulesRoot, entry.name)))
+          continue
+        }
+
+        const realPackageRoot = await this.resolveRealpath(resolve(nodeModulesRoot, entry.name))
+        if (realPackageRoot) {
+          packageRoots.push(realPackageRoot)
+        }
+      }
+    } catch {
+      return []
+    }
+
+    return packageRoots
+  }
+
+  private async resolveScopedPackageRealpaths(scopeRoot: string): Promise<string[]> {
+    const packageRoots: string[] = []
+
+    try {
+      for await (const entry of await opendir(scopeRoot)) {
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+          continue
+        }
+
+        const realPackageRoot = await this.resolveRealpath(resolve(scopeRoot, entry.name))
+        if (realPackageRoot) {
+          packageRoots.push(realPackageRoot)
+        }
+      }
+    } catch {
+      return []
+    }
+
+    return packageRoots
+  }
+
+  private async resolveRealpath(path: string): Promise<string | undefined> {
+    try {
+      return await realpath(path)
+    } catch {
+      return undefined
+    }
   }
 
   private async findFreePort(host: string): Promise<number> {


### PR DESCRIPTION
## What

<!-- Brief description of what this PR does and why. -->
When upgrading to pnpm and using workspaces, we changed where the fontawesome icons and some CSS are served from. Because of vite server's security settings, it was correctly flagging this as serving from an unallowed domain.

## Related issue

<!-- Link the issue this PR addresses. An issue is required before opening a PR. -->

N/A


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

<!-- If selecting "Other", please describe the type of change -->

## Breaking changes

<!-- Does this PR introduce a breaking change? Slide Spec follows semver - breaking changes must be clearly documented. -->

- [ ] Yes (describe below)
- [x] No

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes
