### PR TITLE
chore: add dependabot-npm-force-overrides action

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,6 +17,16 @@ jobs:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - uses: lreading/dependabot-npm-force-overrides@9565f45fa8f140a7d52ce1c34af0c71adfec0ee2 # v1.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:


### PR DESCRIPTION
## What

Adds an action to force dependabot to use package.json overrides instead of package-lock.json only updates

## Related issue

<!-- Link the issue this PR addresses. An issue is required before opening a PR. -->

N/A


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe below)

supply-chain hardening
<!-- If selecting "Other", please describe the type of change -->

## Breaking changes

<!-- Does this PR introduce a breaking change? Slide Spec follows semver - breaking changes must be clearly documented. -->

- [ ] Yes (describe below)
- [x] No

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes
