### PR TITLE
allowlist npx path for cli server

### DIFF
--- a/cli/src/runtime/CliPackagePaths.spec.ts
+++ b/cli/src/runtime/CliPackagePaths.spec.ts
@@ -21,6 +21,7 @@ describe('CliPackagePaths', () => {
     const paths = new CliPackagePaths(root)
     expect(paths.getPackageRoot()).toBe(root)
     expect(paths.getNodeModulesRoot()).toBe(resolve(root, 'node_modules'))
+    expect(paths.getNodeModulesRoots()).toEqual([resolve(root, 'node_modules')])
     expect(paths.getWorkspaceBaseRoot()).toBe(resolve(root, '.runtime-workspaces'))
     expect(paths.getRuntimeTemplateRoot()).toBe(resolve(root, 'dist', 'runtime-template'))
 
@@ -36,6 +37,16 @@ describe('CliPackagePaths', () => {
     expect(() => paths.getRuntimeTemplateRoot()).toThrow(
       'Missing embedded runtime template. Rebuild the CLI package before using build or serve.',
     )
+  })
+
+  it('includes the package-manager node_modules root for scoped npx installs', () => {
+    const root = resolve(tmpdir(), 'slide-spec-npx', 'node_modules', '@slide-spec', 'cli')
+    const paths = new CliPackagePaths(root)
+
+    expect(paths.getNodeModulesRoots()).toEqual([
+      resolve(root, 'node_modules'),
+      resolve(tmpdir(), 'slide-spec-npx', 'node_modules'),
+    ])
   })
 
   it('prefers the built examples and falls back to the synced examples', async () => {

--- a/cli/src/runtime/CliPackagePaths.ts
+++ b/cli/src/runtime/CliPackagePaths.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { dirname, resolve } from 'node:path'
+import { basename, dirname, resolve } from 'node:path'
 
 export class CliPackagePaths {
   private readonly packageRoot: string
@@ -15,6 +15,13 @@ export class CliPackagePaths {
 
   public getNodeModulesRoot(): string {
     return resolve(this.packageRoot, 'node_modules')
+  }
+
+  public getNodeModulesRoots(): string[] {
+    return [
+      this.getNodeModulesRoot(),
+      this.findPackageManagerNodeModulesRoot(),
+    ].filter((path, index, paths): path is string => Boolean(path) && paths.indexOf(path) === index)
   }
 
   public getWorkspaceBaseRoot(): string {
@@ -64,5 +71,19 @@ export class CliPackagePaths {
     }
 
     return packageRoot
+  }
+
+  private findPackageManagerNodeModulesRoot(): string | undefined {
+    let current = this.packageRoot
+
+    while (current !== dirname(current)) {
+      if (basename(current) === 'node_modules') {
+        return current
+      }
+
+      current = dirname(current)
+    }
+
+    return undefined
   }
 }

--- a/cli/src/runtime/ViteSiteDevServer.spec.ts
+++ b/cli/src/runtime/ViteSiteDevServer.spec.ts
@@ -19,6 +19,10 @@ class StubPackagePaths {
   public getNodeModulesRoot(): string {
     return resolve(this.packageRoot, 'node_modules')
   }
+
+  public getNodeModulesRoots(): string[] {
+    return [this.getNodeModulesRoot()]
+  }
 }
 
 class StubRuntimeWorkspace {
@@ -129,6 +133,40 @@ describe('ViteSiteDevServer', () => {
         },
       }),
     }))
+  })
+
+  it('allows hoisted npx dependency package paths from the package manager node_modules root', async () => {
+    const installRoot = await createRoot('slide-spec-npx-install-')
+    const packageRoot = resolve(installRoot, 'node_modules', '@slide-spec', 'cli')
+    const nodeModulesRoot = resolve(installRoot, 'node_modules')
+    const fontPackageRoot = resolve(nodeModulesRoot, '@fontsource', 'poppins')
+    await mkdir(fontPackageRoot, { recursive: true })
+    await mkdir(packageRoot, { recursive: true })
+
+    class NpxPackagePaths extends StubPackagePaths {
+      public override getNodeModulesRoots(): string[] {
+        return [
+          resolve(packageRoot, 'node_modules'),
+          nodeModulesRoot,
+        ]
+      }
+    }
+
+    const viteServer = createViteServerDouble()
+    const createServer = vi.fn(async (_config) => viteServer)
+    const server = new ViteSiteDevServer(
+      new NpxPackagePaths(packageRoot) as never,
+      new StubRuntimeWorkspace() as never,
+      createServer,
+    )
+
+    await expect(server.start({
+      getProjectRoot: () => '/project',
+    } as never, '127.0.0.1', 4173)).resolves.toBe(4173)
+
+    const allow = (createServer.mock.calls[0]?.[0].server?.fs?.allow ?? []) as string[]
+    expect(allow).toContain(nodeModulesRoot)
+    expect(allow).toContain(fontPackageRoot)
   })
 
   it('deduplicates allowed package realpaths and ignores non-package node_modules entries', async () => {

--- a/cli/src/runtime/ViteSiteDevServer.ts
+++ b/cli/src/runtime/ViteSiteDevServer.ts
@@ -84,13 +84,20 @@ export class ViteSiteDevServer {
       workspace.root,
       paths.getProjectRoot(),
       this.packagePaths.getPackageRoot(),
-      this.packagePaths.getNodeModulesRoot(),
+      ...this.packagePaths.getNodeModulesRoots(),
       ...await this.resolveNodeModuleRealpaths(),
     ].filter((path, index, allPaths) => allPaths.indexOf(path) === index)
   }
 
   private async resolveNodeModuleRealpaths(): Promise<string[]> {
-    const nodeModulesRoot = this.packagePaths.getNodeModulesRoot()
+    const packageRoots = await Promise.all(
+      this.packagePaths.getNodeModulesRoots().map((nodeModulesRoot) => this.resolveNodeModuleRootRealpaths(nodeModulesRoot)),
+    )
+
+    return packageRoots.flat().filter((path, index, allPaths) => allPaths.indexOf(path) === index)
+  }
+
+  private async resolveNodeModuleRootRealpaths(nodeModulesRoot: string): Promise<string[]> {
     const packageRoots: string[] = []
 
     try {


### PR DESCRIPTION
## What

Viteserver wasn't serving fonts when run with npx.

## Related issue

<!-- Link the issue this PR addresses. An issue is required before opening a PR. -->

N/A


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

<!-- If selecting "Other", please describe the type of change -->

## Breaking changes

<!-- Does this PR introduce a breaking change? Slide Spec follows semver - breaking changes must be clearly documented. -->

- [ ] Yes (describe below)
- [x] No

<!-- If yes, describe what breaks and any migration steps: -->

## Checklist

- [x] I have tested this locally
- [x] Quality gates passed locally
- [x] Documentation is updated (if applicable)
- [x] No unnecessary dependency changes
